### PR TITLE
turn on token vision and set agent disposition to friendly

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -311,6 +311,8 @@ export default class DeltaGreenActor extends Actor {
         data.prototypeToken,
         {
           actorLink: true, // this will make the 'Link Actor Data' option for a token is checked by default. So changes to the token sheet will reflect to the actor sheet.
+          sight: { enabled: true },
+          disposition: 1 // friendly, this is a dangerous assumption to make in the agency
         },
         { overwrite: false }
       );


### PR DESCRIPTION
without tokenvision, players cannot view scenes by default. 
![image](https://github.com/user-attachments/assets/cb6193b5-567d-42bc-9c02-048cc4809d10)
also set 'agent' disposition to friendly by default
![image](https://github.com/user-attachments/assets/e64d0b58-d369-4261-bb3e-8767503f8674)


https://github.com/drewg13/foundryvtt-scum-and-villainy/issues/89