### PR TITLE
Removed caps in headers

### DIFF
--- a/css/deltagreen.css
+++ b/css/deltagreen.css
@@ -345,7 +345,6 @@ explicitly define a number of rows, rather than columns. */
 
 .deltagreen .resource-label {
   font-weight: bold;
-  text-transform: uppercase;
 }
 
 .sheet nav.sheet-tabs {


### PR DESCRIPTION
Removed caps in headers (resource-label):

Rationale:

In languages other than english, acronyms might be different.

F.i.: Willpower in spanish is _Puntos de (Fuerza de) Voluntad_, the right acronym is PV, but since PV is already used for _Hit Points_ = _Puntos de Vida_ = PV, usually in RPGS in Spain Willpower is shorted as PVo, PV = acronym, and o to distinguish between Hit points and Willpower, so PV = Puntos de Vida, and PVo = Puntos de Voluntad. If the header is PVO, spanish readers will automatically search something different other than Willpower.

This wont affect the english localization since en keys in the en.json file already are already capitalised, but at least let other localization use non capitalized acronyms for stats since sometimes are required.

Thanks!
