### PR TITLE
Arrange compendia in its own folder

### DIFF
--- a/system.json
+++ b/system.json
@@ -85,6 +85,13 @@
       "flags": {}
     }
   ],
+  "packFolders": [{
+      "name": "Delta Green | system",
+      "sorting": "a",
+      "color": "#556b2f",
+      "packs": ["firearms","armor","hand-to-hand-weapons","agent-pregens","operation-code-name-generator-tables","operation-code-name-generator-macro"]
+    }
+  ],
   "packs": [
     {
       "name": "firearms",


### PR DESCRIPTION
Puts system compendia in its own folder _Delta Green | system_.

When there are several modules loaded with different compendia is great to have it organised in different folders.