### PR TITLE
Localize special training skills

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -176,6 +176,7 @@ export default class DeltaGreenActorSheet extends foundry.appv1.sheets
       for (var i = 0; i < data.specialTraining.length; i++) {
         let training = data.specialTraining[i];
 
+        training.attribute = game.i18n.localize(`DG.Skills.${training.key}`);
         training.type = "training";
         training.sortLabel = training.name.toUpperCase();
         training.actorType = this.actor.type;
@@ -1073,7 +1074,7 @@ export default class DeltaGreenActorSheet extends foundry.appv1.sheets
       ([key, skill]) => ({
         value: key,
         group: optionGroups.skills,
-        label: skill.label,
+        label: game.i18n.localize(`DG.Skills.${key}`),
         targetNumber: skill.proficiency,
       })
     );


### PR DESCRIPTION
When adding a special training, the dropdown shows skills in english, instead of localization.

Also, when the skill is shown in actor sheet, the attribute is shown in english, instead of localization.

This MR fixes both issues.