### PR TITLE
Adds support for limited visibility NPC sheets

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -33,25 +33,19 @@ export default class DeltaGreenActorSheet extends foundry.appv1.sheets
   /** @override */
   get template() {
     if (this.actor !== null) {
-      if (this.actor.type === "agent") {
-        if (!game.user.isGM && this.actor.limited) {
-          return "systems/deltagreen/templates/actor/limited-sheet.html";
-        }
-
-        // return `systems/deltagreen/templates/actor/${this.actor.data.type}-sheet.html`;
-        return `systems/deltagreen/templates/actor/actor-sheet.html`;
+      const actorIsLimited = !game.user.isGM && this.actor.limited;
+      switch (this.actor.type) {
+        case "agent":
+          return actorIsLimited ? "systems/deltagreen/templates/actor/limited-sheet.html" : "systems/deltagreen/templates/actor/actor-sheet.html";
+        case "unnatural":
+          return `systems/deltagreen/templates/actor/unnatural-sheet.html`; // No limited sheet
+        case "npc":
+          return actorIsLimited ? "systems/deltagreen/templates/actor/npc-limited-sheet.html" : "systems/deltagreen/templates/actor/npc-sheet.html";
+        case "vehicle":
+          return `systems/deltagreen/templates/actor/vehicle-sheet.html`; // No limited sheet
+        default:
+          return "systems/deltagreen/templates/actor/actor-sheet.html"; // No limited sheet
       }
-      if (this.actor.type === "unnatural") {
-        return `systems/deltagreen/templates/actor/unnatural-sheet.html`;
-      }
-      if (this.actor.type === "npc") {
-        return `systems/deltagreen/templates/actor/npc-sheet.html`;
-      }
-      if (this.actor.type === "vehicle") {
-        return `systems/deltagreen/templates/actor/vehicle-sheet.html`;
-      }
-
-      return "systems/deltagreen/templates/actor/limited-sheet.html";
     }
 
     return "systems/deltagreen/templates/actor/limited-sheet.html";

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -32,23 +32,32 @@ export default class DeltaGreenActorSheet extends foundry.appv1.sheets
 
   /** @override */
   get template() {
+    const templatePath = "systems/deltagreen/templates/actor";
+    let templateName = "limited-sheet.html";
+    
     if (this.actor !== null) {
       const actorIsLimited = !game.user.isGM && this.actor.limited;
+
       switch (this.actor.type) {
         case "agent":
-          return actorIsLimited ? "systems/deltagreen/templates/actor/limited-sheet.html" : "systems/deltagreen/templates/actor/actor-sheet.html";
+          templateName = actorIsLimited ? "limited-sheet.html" : "actor-sheet.html";
+          break;
         case "unnatural":
-          return `systems/deltagreen/templates/actor/unnatural-sheet.html`; // No limited sheet
+          templateName = `unnatural-sheet.html`; // No limited sheet
+          break;
         case "npc":
-          return actorIsLimited ? "systems/deltagreen/templates/actor/npc-limited-sheet.html" : "systems/deltagreen/templates/actor/npc-sheet.html";
+          templateName = actorIsLimited ? "npc-limited-sheet.html" : "npc-sheet.html";
+          break;
         case "vehicle":
-          return `systems/deltagreen/templates/actor/vehicle-sheet.html`; // No limited sheet
+          templateName = `vehicle-sheet.html`; // No limited sheet
+          break;
         default:
-          return "systems/deltagreen/templates/actor/actor-sheet.html"; // No limited sheet
+          templateName = "actor-sheet.html"; // No limited sheet
+          break;
       }
     }
 
-    return "systems/deltagreen/templates/actor/limited-sheet.html";
+    return `${templatePath}/${templateName}`;
   }
 
   /** @override */

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -43,13 +43,13 @@ export default class DeltaGreenActorSheet extends foundry.appv1.sheets
           templateName = actorIsLimited ? "limited-sheet.html" : "actor-sheet.html";
           break;
         case "unnatural":
-          templateName = `unnatural-sheet.html`; // No limited sheet
+          templateName = "unnatural-sheet.html"; // No limited sheet
           break;
         case "npc":
           templateName = actorIsLimited ? "npc-limited-sheet.html" : "npc-sheet.html";
           break;
         case "vehicle":
-          templateName = `vehicle-sheet.html`; // No limited sheet
+          templateName = "vehicle-sheet.html"; // No limited sheet
           break;
         default:
           templateName = "actor-sheet.html"; // No limited sheet

--- a/module/templates.js
+++ b/module/templates.js
@@ -9,6 +9,7 @@ export default async function preloadHandlebarsTemplates() {
     "systems/deltagreen/templates/actor/limited-sheet.html",
     "systems/deltagreen/templates/actor/unnatural-sheet.html",
     "systems/deltagreen/templates/actor/npc-sheet.html",
+    "systems/deltagreen/templates/actor/npc-limited-sheet.html",
     "systems/deltagreen/templates/dialog/modify-percentile-roll.html",
     "systems/deltagreen/templates/actor/vehicle-sheet.html",
     "systems/deltagreen/templates/actor/partials/custom-skills-partial.html",

--- a/templates/actor/npc-limited-sheet.html
+++ b/templates/actor/npc-limited-sheet.html
@@ -1,0 +1,35 @@
+<form class="{{cssClass}} {{getCharacterSheetStyle}} flexcol" autocomplete="off">
+
+    {{!-- Sheet Header --}}
+    <header class="sheet-header">
+        
+      <div class="header-fields">
+        
+        {{!-- Name, Profession, Portrait --}}
+        <div class="flexrow">
+          <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="150" width="100"/>
+          <div class="horizontal-flex-column">
+            <div>
+              <h1 class="charname"><input name="name" type="text" value="{{actor.name}}" title="{{localize 'DG.AgentNameFieldTooltip' }}"/></h1>
+            </div>
+            <div>
+              <h2 class="profession"><input name="system.biography.profession" type="text" value="{{actor.system.biography.profession}}" placeholder="{{localize 'DG.FallbackText.ProfessionAndOrRank'}}"/></h1>
+            </div>
+          </div>
+        </div>
+    </header>
+
+    {{!-- Sheet Tab Navigation --}}
+    <nav class="sheet-tabs tabs" data-group="primary">
+        <a class="item" data-tab="bio">{{localize 'DG.Navigation.CV'}}</a>
+    </nav>
+
+    {{!-- Sheet Body --}}
+    <section class="sheet-body">
+        {{!-- Biography Tab --}}
+        <div class="tab bio" data-group="primary" data-tab="bio">
+          {{> "systems/deltagreen/templates/actor/partials/cv-partial.html" }}
+        </div>
+    </section>
+</form>
+

--- a/templates/actor/npc-limited-sheet.html
+++ b/templates/actor/npc-limited-sheet.html
@@ -18,18 +18,5 @@
           </div>
         </div>
     </header>
-
-    {{!-- Sheet Tab Navigation --}}
-    <nav class="sheet-tabs tabs" data-group="primary">
-        <a class="item" data-tab="bio">{{localize 'DG.Navigation.CV'}}</a>
-    </nav>
-
-    {{!-- Sheet Body --}}
-    <section class="sheet-body">
-        {{!-- Biography Tab --}}
-        <div class="tab bio" data-group="primary" data-tab="bio">
-          {{> "systems/deltagreen/templates/actor/partials/cv-partial.html" }}
-        </div>
-    </section>
 </form>
 


### PR DESCRIPTION
Adds a new sheet template for NPCs who are set to limited visibility. This mostly copies from the existing limited actor sheet but removes the "Personal" tab because NPCs don't seem to have a way to configure that.

## Changes

- Added the new sheet html
- Registered new sheet in templates.js
- Updated actor-sheet.js to return this limited sheet for npcs
- Tidied up the template() function a bit

## Example

### GM or non-limited view

<img width="761" height="790" alt="image" src="https://github.com/user-attachments/assets/a31062bf-fc7a-4897-afc7-a88c93601a4d" />

### Player with limited visibility view

<img width="773" height="800" alt="image" src="https://github.com/user-attachments/assets/69d07e04-c352-44ac-af0e-ae186c08751b" />
