### PR TITLE
refactor(#266): move private sanity logic into prepareContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release/Patch Notes
 
+## Version 1.7.0 - ????-??-??
+
+### **Tech Debt**
+
+- [#267](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/pull/267) - Moved private sanity logic out of templates.
+
 ## Version 1.6.1 - 2025-09-09
 
 > Thanks to the following new contributor: [Tobifroe](https://github.com/tobifroe).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release/Patch Notes
 
-## Version 1.7.0 - ????-??-??
-
-### **Tech Debt**
-
-- [#267](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/pull/267) - Moved private sanity logic out of templates.
-
 ## Version 1.6.1 - 2025-09-09
 
 > Thanks to the following new contributor: [Tobifroe](https://github.com/tobifroe).

--- a/module/sheets/base-actor-sheet.js
+++ b/module/sheets/base-actor-sheet.js
@@ -780,94 +780,110 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
     const currentGroup = typedSkills[targetSkill].group;
 
     let htmlContent = `<div>`;
-    htmlContent += `     <label>${game.i18n.translations.DG?.Skills?.SkillGroup ?? "Skill Group"
-      }:</label>`;
+    htmlContent += `     <label>${
+      game.i18n.translations.DG?.Skills?.SkillGroup ?? "Skill Group"
+    }:</label>`;
     htmlContent += `     <select name="new-type-skill-group" />`;
 
     if (currentGroup === game.i18n.translations.DG?.TypeSkills?.Art ?? "Art") {
-      htmlContent += `          <option value="Art" selected>${game.i18n.translations.DG?.TypeSkills?.Art ?? "Art"
-        }</option>`;
+      htmlContent += `          <option value="Art" selected>${
+        game.i18n.translations.DG?.TypeSkills?.Art ?? "Art"
+      }</option>`;
     } else {
-      htmlContent += `          <option value="Art">${game.i18n.translations.DG?.TypeSkills?.Art ?? "Art"
-        }</option>`;
+      htmlContent += `          <option value="Art">${
+        game.i18n.translations.DG?.TypeSkills?.Art ?? "Art"
+      }</option>`;
     }
 
     if (
       currentGroup === game.i18n.translations.DG?.TypeSkills?.Craft ??
       "Craft"
     ) {
-      htmlContent += `          <option value="Craft" selected>${game.i18n.translations.DG?.TypeSkills?.Craft ?? "Craft"
-        }</option>`;
+      htmlContent += `          <option value="Craft" selected>${
+        game.i18n.translations.DG?.TypeSkills?.Craft ?? "Craft"
+      }</option>`;
     } else {
-      htmlContent += `          <option value="Craft">${game.i18n.translations.DG?.TypeSkills?.Craft ?? "Craft"
-        }</option>`;
+      htmlContent += `          <option value="Craft">${
+        game.i18n.translations.DG?.TypeSkills?.Craft ?? "Craft"
+      }</option>`;
     }
 
     if (
       currentGroup === game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
       "Foreign Language"
     ) {
-      htmlContent += `          <option value="ForeignLanguage" selected>${game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
+      htmlContent += `          <option value="ForeignLanguage" selected>${
+        game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
         "Foreign Language"
-        }</option>`;
+      }</option>`;
     } else {
-      htmlContent += `          <option value="ForeignLanguage">${game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
+      htmlContent += `          <option value="ForeignLanguage">${
+        game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
         "Foreign Language"
-        }</option>`;
+      }</option>`;
     }
 
     if (
       currentGroup === game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
       "Military Science"
     ) {
-      htmlContent += `          <option value="MilitaryScience" selected>${game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
+      htmlContent += `          <option value="MilitaryScience" selected>${
+        game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
         "Military Science"
-        }</option>`;
+      }</option>`;
     } else {
-      htmlContent += `          <option value="MilitaryScience">${game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
+      htmlContent += `          <option value="MilitaryScience">${
+        game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
         "Military Science"
-        }</option>`;
+      }</option>`;
     }
 
     if (
       currentGroup === game.i18n.translations.DG?.TypeSkills?.Pilot ??
       "Pilot"
     ) {
-      htmlContent += `          <option value="Pilot" selected>${game.i18n.translations.DG?.TypeSkills?.Pilot ?? "Pilot"
-        }</option>`;
+      htmlContent += `          <option value="Pilot" selected>${
+        game.i18n.translations.DG?.TypeSkills?.Pilot ?? "Pilot"
+      }</option>`;
     } else {
-      htmlContent += `          <option value="Pilot">${game.i18n.translations.DG?.TypeSkills?.Pilot ?? "Pilot"
-        }</option>`;
+      htmlContent += `          <option value="Pilot">${
+        game.i18n.translations.DG?.TypeSkills?.Pilot ?? "Pilot"
+      }</option>`;
     }
 
     if (
       currentGroup === game.i18n.translations.DG?.TypeSkills?.Science ??
       "Science"
     ) {
-      htmlContent += `          <option value="Science" selected>${game.i18n.translations.DG?.TypeSkills?.Science ?? "Science"
-        }</option>`;
+      htmlContent += `          <option value="Science" selected>${
+        game.i18n.translations.DG?.TypeSkills?.Science ?? "Science"
+      }</option>`;
     } else {
-      htmlContent += `          <option value="Science">${game.i18n.translations.DG?.TypeSkills?.Science ?? "Science"
-        }</option>`;
+      htmlContent += `          <option value="Science">${
+        game.i18n.translations.DG?.TypeSkills?.Science ?? "Science"
+      }</option>`;
     }
 
     if (
       currentGroup === game.i18n.translations.DG?.TypeSkills?.Other ??
       "Other"
     ) {
-      htmlContent += `          <option value="Other" selected>${game.i18n.translations.DG?.TypeSkills?.Other ?? "Other"
-        }</option>`;
+      htmlContent += `          <option value="Other" selected>${
+        game.i18n.translations.DG?.TypeSkills?.Other ?? "Other"
+      }</option>`;
     } else {
-      htmlContent += `          <option value="Other">${game.i18n.translations.DG?.TypeSkills?.Other ?? "Other"
-        }</option>`;
+      htmlContent += `          <option value="Other">${
+        game.i18n.translations.DG?.TypeSkills?.Other ?? "Other"
+      }</option>`;
     }
 
     htmlContent += `     </select>`;
     htmlContent += `</div>`;
 
     htmlContent += `<div>`;
-    htmlContent += `     <label>${game.i18n.translations.DG?.Skills.SkillName ?? "Skill Name"
-      }</label>`;
+    htmlContent += `     <label>${
+      game.i18n.translations.DG?.Skills.SkillName ?? "Skill Name"
+    }</label>`;
     htmlContent += `     <input type="text" name="new-type-skill-label" value="${currentLabel}" />`;
     htmlContent += `</div>`;
 
@@ -905,31 +921,40 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
     let htmlContent = "";
 
     htmlContent += `<div>`;
-    htmlContent += `     <label>${game.i18n.translations.DG?.Skills?.SkillGroup ?? "Skill Group"
-      }:</label>`;
+    htmlContent += `     <label>${
+      game.i18n.translations.DG?.Skills?.SkillGroup ?? "Skill Group"
+    }:</label>`;
     htmlContent += `     <select name="new-type-skill-group" />`;
-    htmlContent += `          <option value="Art">${game.i18n.translations.DG?.TypeSkills?.Art ?? "Art"
-      }</option>`;
-    htmlContent += `          <option value="Craft">${game.i18n.translations.DG?.TypeSkills?.Craft ?? "Craft"
-      }</option>`;
-    htmlContent += `          <option value="ForeignLanguage">${game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
+    htmlContent += `          <option value="Art">${
+      game.i18n.translations.DG?.TypeSkills?.Art ?? "Art"
+    }</option>`;
+    htmlContent += `          <option value="Craft">${
+      game.i18n.translations.DG?.TypeSkills?.Craft ?? "Craft"
+    }</option>`;
+    htmlContent += `          <option value="ForeignLanguage">${
+      game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
       "Foreign Language"
-      }</option>`;
-    htmlContent += `          <option value="MilitaryScience">${game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
+    }</option>`;
+    htmlContent += `          <option value="MilitaryScience">${
+      game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
       "Military Science"
-      }</option>`;
-    htmlContent += `          <option value="Pilot">${game.i18n.translations.DG?.TypeSkills?.Pilot ?? "Pilot"
-      }</option>`;
-    htmlContent += `          <option value="Science">${game.i18n.translations.DG?.TypeSkills?.Science ?? "Science"
-      }</option>`;
-    htmlContent += `          <option value="Other">${game.i18n.translations.DG?.TypeSkills?.Other ?? "Other"
-      }</option>`;
+    }</option>`;
+    htmlContent += `          <option value="Pilot">${
+      game.i18n.translations.DG?.TypeSkills?.Pilot ?? "Pilot"
+    }</option>`;
+    htmlContent += `          <option value="Science">${
+      game.i18n.translations.DG?.TypeSkills?.Science ?? "Science"
+    }</option>`;
+    htmlContent += `          <option value="Other">${
+      game.i18n.translations.DG?.TypeSkills?.Other ?? "Other"
+    }</option>`;
     htmlContent += `     </select>`;
     htmlContent += `</div>`;
 
     htmlContent += `<div>`;
-    htmlContent += `     <label>${game.i18n.translations.DG?.Skills.SkillName ?? "Skill Name"
-      }</label>`;
+    htmlContent += `     <label>${
+      game.i18n.translations.DG?.Skills.SkillName ?? "Skill Name"
+    }</label>`;
     htmlContent += `     <input type="text" name="new-type-skill-label" />`;
     htmlContent += `</div>`;
 
@@ -1067,8 +1092,9 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
       ([key, skill]) => ({
         value: key,
         group: optionGroups.typedSkills,
-        label: `${game.i18n.localize(`DG.TypeSkills.${skill.group}`)} (${skill.label
-          })`,
+        label: `${game.i18n.localize(`DG.TypeSkills.${skill.group}`)} (${
+          skill.label
+        })`,
         targetNumber: skill.proficiency,
       }),
     );

--- a/module/sheets/base-actor-sheet.js
+++ b/module/sheets/base-actor-sheet.js
@@ -94,6 +94,21 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
       this._prepareSkillTooltips();
     }
 
+    // Handle private sanity setting, override for GMs.
+    const keepSanityPrivate = game.settings.get(
+      "deltagreen",
+      "keepSanityPrivate",
+    );
+    if (keepSanityPrivate && !game.user.isGM) {
+      context.maxSan = "???";
+      context.currentSan = "???";
+      context.keepSanityPrivate = true;
+    } else {
+      context.maxSan = this.actor.system.sanity.max;
+      context.currentSan = this.actor.system.sanity.value;
+      context.keepSanityPrivate = false;
+    }
+
     // Set sanity block per actor type.
     context.sanityInputs = await foundry.applications.handlebars.renderTemplate(
       `${DGActorSheet.TEMPLATE_PATH}/partials/sanity-${this.actor.type}.html`,

--- a/module/sheets/base-actor-sheet.js
+++ b/module/sheets/base-actor-sheet.js
@@ -99,15 +99,11 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
       "deltagreen",
       "keepSanityPrivate",
     );
-    if (keepSanityPrivate && !game.user.isGM) {
-      context.maxSan = "???";
-      context.currentSan = "???";
-      context.keepSanityPrivate = true;
-    } else {
-      context.maxSan = this.actor.system.sanity.max;
-      context.currentSan = this.actor.system.sanity.value;
-      context.keepSanityPrivate = false;
-    }
+    const hideSan = keepSanityPrivate && !game.user.isGM;
+
+    context.maxSan = hideSan ? "???" : this.actor.system.sanity.max;
+    context.currentSan = hideSan ? "???" : this.actor.system.sanity.value;
+    context.keepSanityPrivate = keepSanityPrivate;
 
     // Set sanity block per actor type.
     context.sanityInputs = await foundry.applications.handlebars.renderTemplate(
@@ -784,110 +780,94 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
     const currentGroup = typedSkills[targetSkill].group;
 
     let htmlContent = `<div>`;
-    htmlContent += `     <label>${
-      game.i18n.translations.DG?.Skills?.SkillGroup ?? "Skill Group"
-    }:</label>`;
+    htmlContent += `     <label>${game.i18n.translations.DG?.Skills?.SkillGroup ?? "Skill Group"
+      }:</label>`;
     htmlContent += `     <select name="new-type-skill-group" />`;
 
     if (currentGroup === game.i18n.translations.DG?.TypeSkills?.Art ?? "Art") {
-      htmlContent += `          <option value="Art" selected>${
-        game.i18n.translations.DG?.TypeSkills?.Art ?? "Art"
-      }</option>`;
+      htmlContent += `          <option value="Art" selected>${game.i18n.translations.DG?.TypeSkills?.Art ?? "Art"
+        }</option>`;
     } else {
-      htmlContent += `          <option value="Art">${
-        game.i18n.translations.DG?.TypeSkills?.Art ?? "Art"
-      }</option>`;
+      htmlContent += `          <option value="Art">${game.i18n.translations.DG?.TypeSkills?.Art ?? "Art"
+        }</option>`;
     }
 
     if (
       currentGroup === game.i18n.translations.DG?.TypeSkills?.Craft ??
       "Craft"
     ) {
-      htmlContent += `          <option value="Craft" selected>${
-        game.i18n.translations.DG?.TypeSkills?.Craft ?? "Craft"
-      }</option>`;
+      htmlContent += `          <option value="Craft" selected>${game.i18n.translations.DG?.TypeSkills?.Craft ?? "Craft"
+        }</option>`;
     } else {
-      htmlContent += `          <option value="Craft">${
-        game.i18n.translations.DG?.TypeSkills?.Craft ?? "Craft"
-      }</option>`;
+      htmlContent += `          <option value="Craft">${game.i18n.translations.DG?.TypeSkills?.Craft ?? "Craft"
+        }</option>`;
     }
 
     if (
       currentGroup === game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
       "Foreign Language"
     ) {
-      htmlContent += `          <option value="ForeignLanguage" selected>${
-        game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
+      htmlContent += `          <option value="ForeignLanguage" selected>${game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
         "Foreign Language"
-      }</option>`;
+        }</option>`;
     } else {
-      htmlContent += `          <option value="ForeignLanguage">${
-        game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
+      htmlContent += `          <option value="ForeignLanguage">${game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
         "Foreign Language"
-      }</option>`;
+        }</option>`;
     }
 
     if (
       currentGroup === game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
       "Military Science"
     ) {
-      htmlContent += `          <option value="MilitaryScience" selected>${
-        game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
+      htmlContent += `          <option value="MilitaryScience" selected>${game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
         "Military Science"
-      }</option>`;
+        }</option>`;
     } else {
-      htmlContent += `          <option value="MilitaryScience">${
-        game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
+      htmlContent += `          <option value="MilitaryScience">${game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
         "Military Science"
-      }</option>`;
+        }</option>`;
     }
 
     if (
       currentGroup === game.i18n.translations.DG?.TypeSkills?.Pilot ??
       "Pilot"
     ) {
-      htmlContent += `          <option value="Pilot" selected>${
-        game.i18n.translations.DG?.TypeSkills?.Pilot ?? "Pilot"
-      }</option>`;
+      htmlContent += `          <option value="Pilot" selected>${game.i18n.translations.DG?.TypeSkills?.Pilot ?? "Pilot"
+        }</option>`;
     } else {
-      htmlContent += `          <option value="Pilot">${
-        game.i18n.translations.DG?.TypeSkills?.Pilot ?? "Pilot"
-      }</option>`;
+      htmlContent += `          <option value="Pilot">${game.i18n.translations.DG?.TypeSkills?.Pilot ?? "Pilot"
+        }</option>`;
     }
 
     if (
       currentGroup === game.i18n.translations.DG?.TypeSkills?.Science ??
       "Science"
     ) {
-      htmlContent += `          <option value="Science" selected>${
-        game.i18n.translations.DG?.TypeSkills?.Science ?? "Science"
-      }</option>`;
+      htmlContent += `          <option value="Science" selected>${game.i18n.translations.DG?.TypeSkills?.Science ?? "Science"
+        }</option>`;
     } else {
-      htmlContent += `          <option value="Science">${
-        game.i18n.translations.DG?.TypeSkills?.Science ?? "Science"
-      }</option>`;
+      htmlContent += `          <option value="Science">${game.i18n.translations.DG?.TypeSkills?.Science ?? "Science"
+        }</option>`;
     }
 
     if (
       currentGroup === game.i18n.translations.DG?.TypeSkills?.Other ??
       "Other"
     ) {
-      htmlContent += `          <option value="Other" selected>${
-        game.i18n.translations.DG?.TypeSkills?.Other ?? "Other"
-      }</option>`;
+      htmlContent += `          <option value="Other" selected>${game.i18n.translations.DG?.TypeSkills?.Other ?? "Other"
+        }</option>`;
     } else {
-      htmlContent += `          <option value="Other">${
-        game.i18n.translations.DG?.TypeSkills?.Other ?? "Other"
-      }</option>`;
+      htmlContent += `          <option value="Other">${game.i18n.translations.DG?.TypeSkills?.Other ?? "Other"
+        }</option>`;
     }
 
     htmlContent += `     </select>`;
     htmlContent += `</div>`;
 
     htmlContent += `<div>`;
-    htmlContent += `     <label>${
-      game.i18n.translations.DG?.Skills.SkillName ?? "Skill Name"
-    }</label>`;
+    htmlContent += `     <label>${game.i18n.translations.DG?.Skills.SkillName ?? "Skill Name"
+      }</label>`;
     htmlContent += `     <input type="text" name="new-type-skill-label" value="${currentLabel}" />`;
     htmlContent += `</div>`;
 
@@ -925,40 +905,31 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
     let htmlContent = "";
 
     htmlContent += `<div>`;
-    htmlContent += `     <label>${
-      game.i18n.translations.DG?.Skills?.SkillGroup ?? "Skill Group"
-    }:</label>`;
+    htmlContent += `     <label>${game.i18n.translations.DG?.Skills?.SkillGroup ?? "Skill Group"
+      }:</label>`;
     htmlContent += `     <select name="new-type-skill-group" />`;
-    htmlContent += `          <option value="Art">${
-      game.i18n.translations.DG?.TypeSkills?.Art ?? "Art"
-    }</option>`;
-    htmlContent += `          <option value="Craft">${
-      game.i18n.translations.DG?.TypeSkills?.Craft ?? "Craft"
-    }</option>`;
-    htmlContent += `          <option value="ForeignLanguage">${
-      game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
+    htmlContent += `          <option value="Art">${game.i18n.translations.DG?.TypeSkills?.Art ?? "Art"
+      }</option>`;
+    htmlContent += `          <option value="Craft">${game.i18n.translations.DG?.TypeSkills?.Craft ?? "Craft"
+      }</option>`;
+    htmlContent += `          <option value="ForeignLanguage">${game.i18n.translations.DG?.TypeSkills?.ForeignLanguage ??
       "Foreign Language"
-    }</option>`;
-    htmlContent += `          <option value="MilitaryScience">${
-      game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
+      }</option>`;
+    htmlContent += `          <option value="MilitaryScience">${game.i18n.translations.DG?.TypeSkills?.MilitaryScience ??
       "Military Science"
-    }</option>`;
-    htmlContent += `          <option value="Pilot">${
-      game.i18n.translations.DG?.TypeSkills?.Pilot ?? "Pilot"
-    }</option>`;
-    htmlContent += `          <option value="Science">${
-      game.i18n.translations.DG?.TypeSkills?.Science ?? "Science"
-    }</option>`;
-    htmlContent += `          <option value="Other">${
-      game.i18n.translations.DG?.TypeSkills?.Other ?? "Other"
-    }</option>`;
+      }</option>`;
+    htmlContent += `          <option value="Pilot">${game.i18n.translations.DG?.TypeSkills?.Pilot ?? "Pilot"
+      }</option>`;
+    htmlContent += `          <option value="Science">${game.i18n.translations.DG?.TypeSkills?.Science ?? "Science"
+      }</option>`;
+    htmlContent += `          <option value="Other">${game.i18n.translations.DG?.TypeSkills?.Other ?? "Other"
+      }</option>`;
     htmlContent += `     </select>`;
     htmlContent += `</div>`;
 
     htmlContent += `<div>`;
-    htmlContent += `     <label>${
-      game.i18n.translations.DG?.Skills.SkillName ?? "Skill Name"
-    }</label>`;
+    htmlContent += `     <label>${game.i18n.translations.DG?.Skills.SkillName ?? "Skill Name"
+      }</label>`;
     htmlContent += `     <input type="text" name="new-type-skill-label" />`;
     htmlContent += `</div>`;
 
@@ -1096,9 +1067,8 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
       ([key, skill]) => ({
         value: key,
         group: optionGroups.typedSkills,
-        label: `${game.i18n.localize(`DG.TypeSkills.${skill.group}`)} (${
-          skill.label
-        })`,
+        label: `${game.i18n.localize(`DG.TypeSkills.${skill.group}`)} (${skill.label
+          })`,
         targetNumber: skill.proficiency,
       }),
     );

--- a/templates/actor/partials/sanity-agent.html
+++ b/templates/actor/partials/sanity-agent.html
@@ -3,9 +3,7 @@
                   breaking-point-hit{{/if }}"
        type="text"
        name="system.sanity.value"
-       {{#if keepSanityPrivate }}
-       readonly
-       {{/if }}
+       {{disabled keepSanityPrivate}}
        value="{{ currentSan }}"
        data-dtype="Number"
        data-tooltip="{{localize 'DG.Tooltip.CurrentSanityPartOne' }}{{actor.system.sanity.currentBreakingPoint }}{{localize 'DG.Tooltip.CurrentSanityPartTwo' }}" />

--- a/templates/actor/partials/sanity-agent.html
+++ b/templates/actor/partials/sanity-agent.html
@@ -1,27 +1,16 @@
-{{#if (keepSanityPrivate)}}
-<input class="centered"
-       type="text"
-       name="system.sanity.value"
-       value="???"
-       readonly
-       data-dtype="Number" />
-<span>/</span>
-<div class="max-resource-value"
-     data-tooltip="{{localize 'DG.Tooltip.MaximumSanity'}}">
-    <div>???</div>
-</div>
-{{else}}
 <input class="centered
               {{#if actor.system.sanity.breakingPointHit }}
                   breaking-point-hit{{/if }}"
        type="text"
        name="system.sanity.value"
-       value="{{actor.system.sanity.value }}"
+       {{#if keepSanityPrivate }}
+       readonly
+       {{/if }}
+       value="{{ currentSan }}"
        data-dtype="Number"
        data-tooltip="{{localize 'DG.Tooltip.CurrentSanityPartOne' }}{{actor.system.sanity.currentBreakingPoint }}{{localize 'DG.Tooltip.CurrentSanityPartTwo' }}" />
 <span>/</span>
 <div class="max-resource-value"
      data-tooltip="{{localize 'DG.Tooltip.MaximumSanity'}}">
-    <div>{{numberFormat actor.system.sanity.max decimals=0 sign=false}}</div>
+    <div>{{ maxSan }}</div>
 </div>
-{{/if}}


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [x] This is meant for the next release.
- [ ] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

<!-- Briefly describe the purpose of the PR and what it changes. -->
Moves `keepSanityPrivate` logic out of the template into `prepareContext`.
I wasn't quite able to get rid of all logic in the template because of the way HTML `readonly` works, I'm open to suggestions there.

## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Toggle private sanity on/off
2. Look at the agent sheet


## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #266 

## Future Work

<!-- Describe any follow-up work, improvements, or additional features related to this PR. -->
