### PR TITLE
fix (#278): show the tooltip only once for skills without proficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#274] (<https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/274>) - Automated fail marking now works after dice so nice resolve roll.
 - [#268] (<https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/268>) - Removed unnecessary tooltips.
+- [#278] (<https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/278>) - Shows the tooltip only once for skills without proficiency.
 
 ## Version 1.6.1 - 2025-09-09
 

--- a/module/sheets/base-actor-sheet.js
+++ b/module/sheets/base-actor-sheet.js
@@ -413,7 +413,6 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
       skill.tooltip = game.i18n.localize(`DG.Skills.Tooltip.${skill.key}`);
       if (!skill.proficiency) {
         skill.tooltip = skill.tooltip.concat(
-          skill.tooltip,
           "<br><br>",
           game.i18n.localize("DG.Tooltip.CannotRollSkillLabel"),
         );


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [ ] This is meant for the next release.
- [x] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

Removes the second description added to skills without proficiency. 
Before:
<img width="383" height="184" alt="image" src="https://github.com/user-attachments/assets/dc35bf0c-987f-4e7f-9485-3355a82a0b75" />


After:
<img width="411" height="154" alt="image" src="https://github.com/user-attachments/assets/59bd5cc4-5add-4642-95ac-50904bba26d4" />


## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Hover over any skill without proficiency
2. The skill description should show only once in the tooltip

## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #278
