### PR TITLE
feat (#298): don't add art skill in actor creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#268](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/268) - Removed unnecessary tooltips.
 - [#278](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/278) - It shows the tooltip only once for skills without proficiency.
 - [#281](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/281) - Add tooltips to adaptation area.
+- [#298](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/298) - Don't add art skill in actor creation.
 
 ## Version 1.6.1 - 2025-09-09
 

--- a/module/deltagreen.js
+++ b/module/deltagreen.js
@@ -154,30 +154,6 @@ Hooks.on("renderActorDirectory", (app, html, data) => {
   }
 });
 
-/**
- * We use this hook to translate the sample Typed Skill
- * Note - this event is fired on only the client who did the create action.
- */
-// eslint-disable-next-line no-unused-vars
-Hooks.on("preCreateActor", async (actor, creationData, options, userId) => {
-  // On brand new actors, creationData only has properties: `name`, and `type`.
-  // If creationData has `system` then the new actor is either duplicated or imported,
-  // We only want to translate the sample Typed Skill on brand new actors,
-  // thus we return early if creationData has the `system` property so we do not override anything.
-  // Also, only translate actor types with a default Typed Skill (agents and NPCs)
-  if (creationData?.system || !["agent", "npc"].includes(actor.type)) return;
-
-  // Translate the default typed skill for brand new actors.
-  actor.updateSource({
-    "system.typedSkills.tskill_01": {
-      label: game.i18n.localize("DG.TypeSkills.Subskills.Painting"),
-      group: game.i18n.localize("DG.TypeSkills.Art"),
-      proficiency: 0,
-      failure: false,
-    },
-  });
-});
-
 // Note - this event is fired on ALL connected clients...
 Hooks.on("createActor", async (actor, options, userId) => {
   try {


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [x] This is meant for the next release.
- [x] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

Removes the art skill that is added when an agent or NPC is created. 

Before:
<img width="751" height="180" alt="image" src="https://github.com/user-attachments/assets/6c3d99f7-d3e2-4d3f-8eae-00079c64a317" />


After:
<img width="755" height="174" alt="image" src="https://github.com/user-attachments/assets/ddea4525-a701-426f-94be-ef616e7b5e73" />


## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Create an agent or NPC
2. They shouldn't have the art skill added as default

## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #298 

