### PR TITLE
fix (#301): SAN doesn't zero out when player updates sheet with sanity private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#278](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/278) - It shows the tooltip only once for skills without proficiency.
 - [#281](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/281) - Add tooltips to adaptation area.
 - [#298](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/298) - Don't add art skill in actor creation.
+- [#301](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/301) - SAN doesn't zero out when player updates sheet and the sanity is private.
 
 ## Version 1.6.1 - 2025-09-09
 

--- a/templates/actor/partials/sanity-agent.html
+++ b/templates/actor/partials/sanity-agent.html
@@ -1,10 +1,7 @@
 {{#if (keepSanityPrivate) }}
-    <input class="centered"
-           type="text"
-           name="system.sanity.value"
-           value="???"
-           readonly
-           data-dtype="Number" />
+    <div class="max-resource-value">
+        <div>???</div>
+    </div>
     <span>/</span>
     <div class="max-resource-value"
          data-tooltip="{{localize 'DG.Tooltip.MaximumSanity'}}">


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [ ] This is meant for the next release.
- [x] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

Fixes a problem when a player updates an agent sheet and the SAN is zero out

## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Update the settings to keep the SAN private
2. As the GM, open an agent and update the SAN to have a value
3. As a player, open the same agent sheet and update anything on it
4. The agent should keep the same SAN the GM entered

## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #301

