### PR TITLE
feat (#211): move macros to System macros folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release/Patch Notes
 
+## Version 1.7.0 - 2025-xx-xx
+
+### **Features:**
+
+- [#211](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/211) - Move macros to System macros folder in compendium.
+
 ## Version 1.6.1 - 2025-09-09
 
 > Thanks to the following new contributor: [Tobifroe](https://github.com/tobifroe).

--- a/system.json
+++ b/system.json
@@ -101,8 +101,15 @@
         "armor",
         "hand-to-hand-weapons",
         "agent-pregens",
-        "operation-code-name-generator-tables",
-        "operation-code-name-generator-macro"
+        "operation-code-name-generator-tables"
+      ],
+      "folders": [
+        {
+          "name": "System macros",
+          "sorting": "a",
+          "color": "#67b1e0",
+          "packs": ["operation-code-name-generator-macro"]
+        }
       ]
     }
   ],


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [ ] This is meant for the next release.
- [x] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

Creates a new folder called `System macros` in the compendium and moves the `operation codename macro` into it.

## How to Test

1. Create a new Delta Green world
2. Run it and go to the Delta Green compendium 
3. You should see a new folder called `System macros` and the `operation codename macro` in it

Example: 
<img width="301" height="508" alt="image" src="https://github.com/user-attachments/assets/1db8d4a9-8649-4d42-83f0-3e43cb9adc22" />


## Related Issue(s)

Closes #211 
