### PR TITLE
fix (#316): remove custom border from pressed, toggle and action buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - [#312](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/312) - Add tooltip to Breaking point.
 
+### **Bug Fixes:**
+
+- [#316](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/316) - Remove the custom border from pressed, toggle and action buttons.
+
 ## Version 1.6.3 - 2025-12-12
 
 > Skips v1.6.2 due to a mistake in the release process. Oops.

--- a/css/deltagreen.css
+++ b/css/deltagreen.css
@@ -209,7 +209,7 @@ input.breaking-point-hit {
   grid-template-columns: repeat(12, minmax(0, 1fr));
 }
 
-/* If the user wishes to sort skills by column, we need to 
+/* If the user wishes to sort skills by column, we need to
 explicitly define a number of rows, rather than columns. */
 .grid-13row {
   grid-template-rows: repeat(13, minmax(0, auto)) !important;
@@ -1091,7 +1091,7 @@ input.item-sheet-short-input {
   padding-right: 5px;
 }
 
-/* 
+/*
   Tome Item Sheet
 */
 
@@ -1259,6 +1259,11 @@ a[data-action="applySkillImprovements"] {
   scrollbar-color: var(--color-text-dark-header) #111 !important;
 }
 
+#interface:not(.theme-light) * {
+  --control-border-color: #215112;
+  --control-hover-border-color: #215112;
+}
+
 /* The logo is defunct as of v13 */
 #logo {
   content: url("../assets/img/Delta_Green_Logo.webp");
@@ -1266,14 +1271,6 @@ a[data-action="applySkillImprovements"] {
   height: auto;
   padding-top: 10px;
   padding-bottom: 10px;
-}
-
-body:not(.no-theme) #interface:not(.theme-light) .ui-control {
-  border: 2px solid #215112;
-}
-
-body:not(.no-theme) #interface:not(.theme-light) #action-bar .slot.full:hover {
-  border: 2px solid #215112;
 }
 
 .target-proficiency-mod {


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [ ] This is meant for the next release.
- [x] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

Removes the custom green border from buttons that are pressed, toggled, or perform an action.

## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->
1. Open any game
2. You should see the border of the pressed buttons

Before:
<img width="86" height="439" alt="image" src="https://github.com/user-attachments/assets/e379ff8e-0ff0-47ee-a065-1f51ed930b01" />


After:

<img width="85" height="486" alt="image" src="https://github.com/user-attachments/assets/15c3275a-4b21-4d09-8bef-7aa62b28ff3d" />







## Related Issue(s)

Closes #316

##
<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->


