### PR TITLE
feat (#296): remove adaptation checks if not adapted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Release/Patch Notes
 
-## Version 1.7.0 - 2025-xx-xx
+## Version 1.7.0 - 2026-xx-xx
+
+> Thanks to [hknmtt](https://github.com/hknmtt) for updating the Brazilian translation.
 
 ### **Features:**
 
+- [#296](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/296) - Remove adaptation checks if not adapted.
 - [#281](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/281) - Add tooltips to checkboxes in adaptation area.
 - [#211](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/211) - Move macros to System macros folder in compendium.
 - [#283](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/283) - Added new actor sheet with left hand Sidebar RFC

--- a/module/sheets/agent-sheet.js
+++ b/module/sheets/agent-sheet.js
@@ -101,9 +101,21 @@ export default class DGAgentSheet extends DGActorSheet {
       0,
     );
 
-    this.actor.update({
+    const dataToUpdate = {
       "system.sanity.currentBreakingPoint": currentBreakingPoint,
-    });
+    };
+    if (!this.actor.system.sanity.adaptations.violence.isAdapted) {
+      dataToUpdate["system.sanity.adaptations.violence.incident1"] = false;
+      dataToUpdate["system.sanity.adaptations.violence.incident2"] = false;
+      dataToUpdate["system.sanity.adaptations.violence.incident3"] = false;
+    }
+    if (!this.actor.system.sanity.adaptations.helplessness.isAdapted) {
+      dataToUpdate["system.sanity.adaptations.helplessness.incident1"] = false;
+      dataToUpdate["system.sanity.adaptations.helplessness.incident2"] = false;
+      dataToUpdate["system.sanity.adaptations.helplessness.incident3"] = false;
+    }
+
+    this.actor.update(dataToUpdate);
   }
 
   /**


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [x] This is meant for the next release.
- [ ] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

It removes adaptation checks when the `Reset breaking point` button is clicked, and the agent is not adapted.

## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Open an agent
2. Go to the Psychological tab
3. Select some of the adaptation checkboxes for Violence or Helplessness (not all of them)
4. Click the `Reset breaking point` button
5. The adaptation checkboxes should become unchecked
6. Select all of the adaptation checkboxes
7. Click on the `Reset breaking point` button
8. The adaptation checkboxes should remain checked

## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #296 
