### PR TITLE
Fix #328 - Exclude Unnatural from Marked Failed Checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### **Features:**
 
 - [#312](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/312) - Add tooltip to Breaking point.
+- [#328](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/328) - Exclude Unnatural from Marked Failed Checks
 
 ### **Bug Fixes:**
 

--- a/module/roll/roll.js
+++ b/module/roll/roll.js
@@ -285,6 +285,7 @@ export class DGPercentileRoll extends DGRoll {
       this.actor?.type === "agent" &&
       !this.isSuccess &&
       this.skillPath &&
+      this.key !== "unnatural" &&
       !foundry.utils.getProperty(this.actor, `${this.skillPath}.failure`) &&
       game.settings.get(DG.ID, "skillFailure");
 


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [ ] This is meant for the next release.
- [x] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

<!-- Briefly describe the purpose of the PR and what it changes. -->

## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Open a character sheet with the Unnatural skill
2. Roll a skill check for the Unnatural skill
3. Fail the skill check (roll above the skill rating)
4. Check that mark is not exists

## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #328

## Future Work

<!-- Describe any follow-up work, improvements, or additional features related to this PR. -->
