### PR TITLE
feat (#312): add tooltip to breaking point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release/Patch Notes
 
+## Version 1.6.4 - 2026-xx-xx
+
+> Thanks to [666f78](https://github.com/666f78) for adding the Ukrainian translation.
+
+### **Features:**
+
+- [#312](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/312) - Add tooltip to Breaking point.
+
 ## Version 1.6.3 - 2025-12-12
 
 > Skips v1.6.2 due to a mistake in the release process. Oops.

--- a/lang/en.json
+++ b/lang/en.json
@@ -182,7 +182,7 @@
   "DG.Generic.AddButtonLabel": "Add",
 
   "DG.Mental.BreakingPoint": "Breaking Point: ",
-  "DG.Mental.Tooltip.BreakingPoint": "The Breaking Point is the exact point of SAN at which your Agent has been worn down enough by trauma to develop a new, long-term mental disorder. If SAN reaches that point or below, subtract your Agent’s POW from the new SAN. That’s your Agent’s new Breaking Point.",
+  "DG.Mental.Tooltip.BreakingPoint": "When SAN falls to or below this number, Agent gains a long-term mental disorder; set a new Breaking Point to current SAN - POW. Disorders remain even if SAN later rises above a previous Breaking Point.",
   "DG.Mental.Reset": "Reset",
   "DG.Mental.SanityLossIncidentsLabel": "Incidents of SAN Loss Without Going Insane",
   "DG.Mental.Violence": "Violence",

--- a/templates/actor/parts/motivations-tab.html
+++ b/templates/actor/parts/motivations-tab.html
@@ -7,7 +7,10 @@
     </div>
     <div>
         <div class="breaking-point-grid-3col">
-            <label class="bolded-label">{{localize 'DG.Mental.BreakingPoint'}}</label>
+            <label class="bolded-label"
+                   data-tooltip="{{localize 'DG.Mental.Tooltip.BreakingPoint'}}">
+                {{localize 'DG.Mental.BreakingPoint'}}
+            </label>
             <input class="centered"
                    title="{{localize 'DG.Tooltip.BreakPoint'}}"
                    type="text"


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [ ] This is meant for the next release.
- [x] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

<!-- Briefly describe the purpose of the PR and what it changes. -->

## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Open an agent sheet
2. Go to the Psychological tab
3. Move the mouse over the Breaking Point label
4. You should see the new tooltip


Example: 
<img width="582" height="193" alt="image" src="https://github.com/user-attachments/assets/70b30c22-6eb3-4362-8cd7-ed29f3c07238" />


## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #312 

