### PR TITLE
feat (#338): remove checkbox for unnatural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### **Features:**
 
 - [#312](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/312) - Add tooltip to Breaking point.
-- [#328](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/328) - Exclude Unnatural from Marked Failed Checks
+- [#328](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/328) - Exclude Unnatural from Marked Failed Checks.
+- [#338](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/338) - Remove checkbox for unnatural skill.
 
 ### **Bug Fixes:**
 

--- a/css/deltagreen.css
+++ b/css/deltagreen.css
@@ -543,6 +543,10 @@ input.checkbox-skill-input {
   width: 1px;
 }
 
+input.checkbox-skill-input:disabled {
+  visibility: hidden;
+}
+
 .deltagreen .sheet-header .header-top {
   margin-bottom: 5px;
 }

--- a/module/sheets/agent-sheet.js
+++ b/module/sheets/agent-sheet.js
@@ -115,9 +115,11 @@ export default class DGAgentSheet extends DGActorSheet {
   static async _processSkillImprovements() {
     const { skills, typedSkills } = this.actor.system;
 
-    const failedSkills = Object.values(skills).filter((skill) => skill.failure);
+    const failedSkills = Object.values(skills).filter(
+      (skill) => skill.failure && !skill.cannotBeImprovedByFailure,
+    );
     const failedTypedSkills = Object.values(typedSkills).filter(
-      (skill) => skill.failure,
+      (skill) => skill.failure && !skill.cannotBeImprovedByFailure,
     );
 
     if (failedSkills.length + failedTypedSkills.length === 0) {


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [ ] This is meant for the next release.
- [x] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

It removes the "marked for improvement" checkbox for the unnatural skill. Also, it ignores skills that can't be improved by failure in the "Apply Skill Improvements" action.

## How to Test

<img width="764" height="155" alt="image" src="https://github.com/user-attachments/assets/451369e0-909b-46fb-9614-765364c604f0" />

1. Open an agent
2. You shouldn't see the checkbox next to unnatural skill
3. Click on the button "Apply Skill Improvements"
4. The unnatural skill value shouldn't change

## Related Issue(s)

Closes #338 
