### PR TITLE
fix (#355): save physical description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 - [#283](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/283) - Added new actor sheet with left hand Sidebar RFC
 - [#291](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/291) - Moving Luck button from three dots to left hand panel
 
+## Version 1.6.6 - 2026-02-XX
+
+### **Bug Fixes:**
+
+- [#355](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/355) - Save the physical description of an agent.
+
 ## Version 1.6.4 - 2026-02-12
 
 > Thanks to [666f78](https://github.com/666f78) for adding the Ukrainian translation.

--- a/module/data/actor/agent.js
+++ b/module/data/actor/agent.js
@@ -30,7 +30,7 @@ export default class AgentData extends CharacterData {
       }),
       physical: new SchemaField({
         description: new StringField({
-          initial: "(Physical description of agent)",
+          initial: "",
         }),
         wounds: new StringField({ initial: "" }),
         firstAidAttempted: new BooleanField({ initial: false }),

--- a/module/sheets/agent-sheet.js
+++ b/module/sheets/agent-sheet.js
@@ -63,31 +63,6 @@ export default class DGAgentSheet extends DGActorSheet {
 
   /* -------------------------------------------- */
 
-  /** @override */
-  async _prepareContext(options) {
-    const context = await super._prepareContext(options);
-
-    const enrichedDescription =
-      await foundry.applications.ux.TextEditor.implementation.enrichHTML(
-        this.actor.system.physicalDescription,
-        {
-          rollData: this.document.getRollData(),
-          relativeTo: this.document,
-        },
-      );
-    const { HTMLProseMirrorElement } = foundry.applications.elements;
-    context.descriptionField = HTMLProseMirrorElement.create({
-      name: "system.physicalDescription",
-      value: this.actor.system.physicalDescription,
-      enriched: enrichedDescription,
-      toggled: true,
-    }).outerHTML;
-
-    return context;
-  }
-
-  /* -------------------------------------------- */
-
   /**
    * Resets the actor's current breaking point by recalculating it as the difference
    * between the actor's sanity value and POW value, ensuring it is non-negative,

--- a/module/sheets/base-actor-sheet.js
+++ b/module/sheets/base-actor-sheet.js
@@ -299,7 +299,7 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
 
     switch (this.actor.type) {
       case "agent":
-        descriptionPath = "system.physicalDescription";
+        descriptionPath = "system.physical.description";
         break;
       case "npc":
       case "unnatural":


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [ ] This is meant for the next release.
- [x] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

Fixes a problem saving the physical description of an agent.

## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Open an agent
2. Go to Personal tab
3. Edit the physical description/notes and save them
4. You should see the changes

<img width="776" height="790" alt="image" src="https://github.com/user-attachments/assets/54700121-4403-4532-8b78-24efad4c035b" />


## Related Issue(s)

Closes #355 
