### PR TITLE
fix (#359): save profession npc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@
 - [#283](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/283) - Added new actor sheet with left hand Sidebar RFC
 - [#291](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/291) - Moving Luck button from three dots to left hand panel
 
-## Version 1.6.6 - 2026-02-XX
+## Version 1.6.6 - 2026-03-XX
 
 ### **Bug Fixes:**
 
 - [#355](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/355) - Save the physical description of an agent.
+- [#359](https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/issues/359) - Save the profession of an NPC.
 
 ## Version 1.6.4 - 2026-02-12
 

--- a/module/data/actor/npc.js
+++ b/module/data/actor/npc.js
@@ -16,6 +16,9 @@ export default class NPCData extends CharacterData {
         value: new NumberField({ initial: 100 }),
         currentBreakingPoint: new NumberField({ initial: 101 }),
       }),
+      biography: new SchemaField({
+        profession: new StringField({ initial: "" }),
+      }),
       notes: new StringField({ initial: "" }),
       shortDescription: new StringField({ initial: "" }),
       showUntrainedSkills: new BooleanField({ initial: true }),


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [ ] This is meant for the next release.
- [x] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

Fixes a problem saving the profession of an NPC.

## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Open an NPC
2. Update the profession
3. The profession should be saved

## Related Issue(s)

Closes #359 
