### PR TITLE
fix: resolve no-await-in-loop warnings with Promise.all

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -314,14 +314,14 @@ export default class DeltaGreenActor extends Actor {
     try {
       let alreadyAdded = false;
 
-      for (const item of this.items) {
-        const flag = await item.getFlag("deltagreen", "SystemName");
+      const flags = await Promise.all(
+        this.items.map((item) => item.getFlag("deltagreen", "SystemName")),
+      );
 
-        if (flag === "unarmed-attack" || item.name === "Unarmed Attack") {
-          alreadyAdded = true;
-          break;
-        }
-      }
+      alreadyAdded = this.items.some(
+        (item, index) =>
+          flags[index] === "unarmed-attack" || item.name === "Unarmed Attack",
+      );
 
       if (alreadyAdded === true) {
         return;
@@ -333,23 +333,27 @@ export default class DeltaGreenActor extends Actor {
       const itemIndex = await handToHandPack.getIndex();
       const toAdd = []; // createEmbeddedDocument expects an array
 
-      for (const idx of itemIndex) {
-        const _temp = await handToHandPack.getDocument(idx._id);
+      const documents = await Promise.all(
+        itemIndex.map((idx) => handToHandPack.getDocument(idx._id)),
+      );
 
-        if (_temp.name === "Unarmed Attack") {
-          toAdd.push(_temp);
+      for (const doc of documents) {
+        if (doc.name === "Unarmed Attack") {
+          toAdd.push(doc);
         }
       }
 
       const newItems = await this.createEmbeddedDocuments("Item", toAdd);
 
-      for (const item of newItems) {
-        await item.setFlag("deltagreen", "AutoAdded", true);
+      await Promise.all(
+        newItems.map(async (item) => {
+          await item.setFlag("deltagreen", "AutoAdded", true);
 
-        if (item.name === "Unarmed Attack") {
-          await item.setFlag("deltagreen", "SystemName", "unarmed-attack");
-        }
-      }
+          if (item.name === "Unarmed Attack") {
+            await item.setFlag("deltagreen", "SystemName", "unarmed-attack");
+          }
+        }),
+      );
     } catch (ex) {
       console.log("Error adding unarmed strike item to Actor.");
       console.log(ex);
@@ -382,9 +386,9 @@ export default class DeltaGreenActor extends Actor {
         // create the item on the actor
         const newItems = await this.createEmbeddedDocuments("Item", toAdd);
 
-        for (const item of newItems) {
-          await item.setFlag("deltagreen", "AutoAdded", true);
-        }
+        await Promise.all(
+          newItems.map((item) => item.setFlag("deltagreen", "AutoAdded", true)),
+        );
       }
     } catch (ex) {
       console.log(ex);

--- a/module/other/stat-parser-macro.js
+++ b/module/other/stat-parser-macro.js
@@ -613,24 +613,26 @@ async function RegexParseNpcStatBlock(inputStr, actorType) {
   }
 
   if (attacks !== null && attacks.length > 0) {
-    for (const a of attacks) {
-      await newActors[0].AddWeaponItemToSheet(
-        a.name,
-        a.description,
-        a.damage,
-        a.skill,
-        a.skillModifier,
-        a.customSkillTarget,
-        a.armorPiercing,
-        a.lethality,
-        a.isLethal,
-        a.range,
-        a.killRadius,
-        a.ammo,
-        a.expense,
-        a.equipped,
-      );
-    }
+    await Promise.all(
+      attacks.map((a) =>
+        newActors[0].AddWeaponItemToSheet(
+          a.name,
+          a.description,
+          a.damage,
+          a.skill,
+          a.skillModifier,
+          a.customSkillTarget,
+          a.armorPiercing,
+          a.lethality,
+          a.isLethal,
+          a.range,
+          a.killRadius,
+          a.ammo,
+          a.expense,
+          a.equipped,
+        ),
+      ),
+    );
   }
 
   newActors[0].sheet.render(true);


### PR DESCRIPTION
## Summary

This PR addresses the `no-await-in-loop` lint warnings referenced in #405 by replacing sequential asynchronous operations with `Promise.all()` and `Array.map()` where appropriate.

## Changes

* Refactored asynchronous flag retrieval in `AddUnarmedAttackItemIfMissing()`
* Refactored compendium document loading to avoid awaiting within loops
* Refactored item flag updates after document creation
* Refactored weapon creation logic in `stat-parser-macro.js` to use concurrent async execution

## Impact

* Eliminates the targeted `no-await-in-loop` warnings
* Preserves existing functionality and behavior
* No user-facing changes expected

## Testing

* Ran `npm run lint`
* Verified that the targeted `no-await-in-loop` warnings are no longer reported
* Confirmed successful lint execution with no errors

Related to #405
