### PR TITLE
Fix translating "New Item" string

### DIFF
--- a/module/sheets/base-actor-sheet.js
+++ b/module/sheets/base-actor-sheet.js
@@ -752,12 +752,9 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
    */
   _onItemCreate(type) {
     // Initialize a default name.
-    const name = game.i18n.format(
-      game.i18n.translations.DOCUMENT?.New || "DG.FallbackText.newItem",
-      {
-        type: game.i18n.localize(`TYPES.Item.${type}`),
-      },
-    );
+    const name = game.i18n.format("DG.FallbackText.newItem", {
+      type: game.i18n.localize(`TYPES.Item.${type}`),
+    });
 
     // Prepare the item object.
     const itemData = {


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [x] This is meant for the next release.

## What does this PR do?

Just a localization/formatting issue. I think we were referencing an old Foundry key that doesn't exist anymore. Either way, might as well just use our own string

## How to Test

<!-- List steps to test the feature or fix. Include any setup instructions. -->

1. Create a new Bond or Motivation on a Agent sheet. 
2. Note that the resulting string looks like "New Bond" or "New Motivation" instead of "New {type}".
