### PR TITLE
Convert game.i18n.{localize,format} calls to global _loc

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -68,6 +68,7 @@ globals:
   mergeObject: readonly
   setProperty: readonly
   ui: readonly
+  _loc: readonly
 settings:
   import/extensions:
     - ".js"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -627,9 +627,9 @@ Do **not** hardcode text directly into HTML or JavaScript. Instead, use localiza
 - **JavaScript**:
 
   ```js
-  game.i18n.localize("DG.Skills.accounting");
+  _loc("DG.Skills.accounting");
   // Or for string interpolation:
-  game.i18n.format("DG.FallbackText.newItem", {
+  _loc("DG.FallbackText.newItem", {
     type: "TYPES.Item.weapon",
   });
   ```

--- a/module/other/register-helpers.js
+++ b/module/other/register-helpers.js
@@ -127,12 +127,12 @@ export default function registerHandlebarsHelpers() {
 
     try {
       if (skill === "dex") {
-        label = game.i18n.localize("DG.Attributes.dex");
+        label = _loc("DG.Attributes.dex");
       }
       if (skill === "DG.Skills.custom") {
-        label = game.i18n.localize("DG.ItemWindow.Custom");
+        label = _loc("DG.ItemWindow.Custom");
       } else {
-        label = game.i18n.localize(`DG.Skills.${skill}`);
+        label = _loc(`DG.Skills.${skill}`);
       }
     } catch (error) {
       console.log(error);

--- a/module/other/utility-functions.js
+++ b/module/other/utility-functions.js
@@ -9,7 +9,7 @@ export default class DGUtils {
    */
   static localizeWithFallback(key, fallback) {
     try {
-      const translatedValue = game.i18n.localize(key);
+      const translatedValue = _loc(key);
       if (translatedValue !== key) {
         return translatedValue;
       }

--- a/module/roll/roll.js
+++ b/module/roll/roll.js
@@ -98,18 +98,18 @@ export class DGPercentileRoll extends DGRoll {
         // If this weapon uses a custom target for rolls, we set that explicitly.
         if (this.key === "custom") {
           this.target = this.item.system.customSkillTarget;
-          this.localizedKey = game.i18n.localize("DG.ItemWindow.Custom");
+          this.localizedKey = _loc("DG.ItemWindow.Custom");
         }
         // Add a the weapon's internal modifier.
         this.modifier += this.item.system.skillModifier;
         break;
       case "sanity":
         this.target = this.actor.system.sanity.value;
-        this.localizedKey = game.i18n.localize("DG.Attributes.SAN");
+        this.localizedKey = _loc("DG.Attributes.SAN");
         break;
       case "luck":
         this.target = 50;
-        this.localizedKey = game.i18n.localize("DG.Luck");
+        this.localizedKey = _loc("DG.Luck");
         break;
       default:
         break;
@@ -267,18 +267,18 @@ export class DGPercentileRoll extends DGRoll {
 
     if (this.isSuccess) {
       if (this.isCritical) {
-        resultString = `${game.i18n.localize("DG.Roll.CriticalSuccess")}`;
+        resultString = `${_loc("DG.Roll.CriticalSuccess")}`;
         resultString = `${resultString.toUpperCase()}`;
         styleOverride = "color: green";
       } else {
-        resultString = `${game.i18n.localize("DG.Roll.Success")}`;
+        resultString = `${_loc("DG.Roll.Success")}`;
       }
     } else if (this.isCritical) {
-      resultString = `${game.i18n.localize("DG.Roll.CriticalFailure")}`;
+      resultString = `${_loc("DG.Roll.CriticalFailure")}`;
       resultString = `${resultString.toUpperCase()}`;
       styleOverride = "color: red";
     } else {
-      resultString = `${game.i18n.localize("DG.Roll.Failure")}`;
+      resultString = `${_loc("DG.Roll.Failure")}`;
     }
 
     const failureMark =
@@ -351,14 +351,14 @@ export class DGPercentileRoll extends DGRoll {
     let skillPath = null; // For optimization of failure checks
     if (statKeys.includes(this.key)) {
       target = actorData.statistics[this.key].x5;
-      localizedKey = game.i18n.localize(`DG.Attributes.${this.key}`);
+      localizedKey = _loc(`DG.Attributes.${this.key}`);
     }
     if (skillKeys.includes(this.key)) {
       // use calculated target proficiency (effects and etc like aim + 20%)
       target =
         actorData.skills[this.key].targetProficiency ||
         actorData.skills[this.key].proficiency;
-      localizedKey = game.i18n.localize(`DG.Skills.${this.key}`);
+      localizedKey = _loc(`DG.Skills.${this.key}`);
       skillPath = `system.skills.${this.key}`;
     }
     if (typedSkillKeys.includes(this.key)) {
@@ -369,7 +369,7 @@ export class DGPercentileRoll extends DGRoll {
     }
     if (this.key === "ritual") {
       target = actorData.sanity.ritual;
-      localizedKey = game.i18n.localize(`DG.Skills.ritual`);
+      localizedKey = _loc(`DG.Skills.ritual`);
     }
     return { target, localizedKey, skillPath };
   }
@@ -382,12 +382,8 @@ export class DGPercentileRoll extends DGRoll {
    * @returns {string}
    */
   createLabel() {
-    const startOfLabel = `${game.i18n.localize("DG.Roll.Rolling")} <b>${
-      this.localizedKey
-    }`;
-    const endOfLabel = `${game.i18n.localize("DG.Roll.Target")} ${
-      this.effectiveTarget
-    }`;
+    const startOfLabel = `${_loc("DG.Roll.Rolling")} <b>${this.localizedKey}`;
+    const endOfLabel = `${_loc("DG.Roll.Target")} ${this.effectiveTarget}`;
 
     let label = this.isInhuman
       ? // "Inhuman" stat being rolled. See function for details.
@@ -557,7 +553,7 @@ export class DGLethalityRoll extends DGPercentileRoll {
   constructor(formula, data, options) {
     super(formula, data, options);
     this.target = options.item.system.lethality;
-    this.localizedKey = game.i18n.localize("DG.ItemWindow.Weapons.Lethality");
+    this.localizedKey = _loc("DG.ItemWindow.Weapons.Lethality");
   }
 
   /**
@@ -575,20 +571,20 @@ export class DGLethalityRoll extends DGPercentileRoll {
     let resultString = "";
     let styleOverride = "";
     if (this.total <= this.target) {
-      resultString = `${game.i18n.localize("DG.Roll.Lethal").toUpperCase()}`;
+      resultString = `${_loc("DG.Roll.Lethal").toUpperCase()}`;
       styleOverride = "color: red";
     } else {
-      resultString = `${game.i18n.localize("DG.Roll.Failure")}`;
+      resultString = `${_loc("DG.Roll.Failure")}`;
     }
 
     const { nonLethalDamage } = this;
-    let label = `${game.i18n.localize("DG.Roll.Rolling")} <b>${game.i18n
+    let label = `${_loc("DG.Roll.Rolling")} <b>${game.i18n
       .localize("DG.Roll.Lethality")
-      .toUpperCase()}</b> ${game.i18n.localize(
+      .toUpperCase()}</b> ${_loc(
       "DG.Roll.For",
-    )} <b>${this.item.name.toUpperCase()}</b> ${game.i18n.localize(
-      "DG.Roll.Target",
-    )} ${this.target + this.modifier}`;
+    )} <b>${this.item.name.toUpperCase()}</b> ${_loc("DG.Roll.Target")} ${
+      this.target + this.modifier
+    }`;
     if (this.modifier) {
       label += ` (${DGUtils.formatStringWithLeadingPlus(this.modifier)}%)`;
     }
@@ -631,7 +627,7 @@ export class DGLethalityRoll extends DGPercentileRoll {
     html += `     </div>`;
     html += `     <h4 class="dice-total">${this.total} (${
       nonLethalDamage.total
-    } ${game.i18n.localize("DG.Roll.Damage")})</h4>`;
+    } ${_loc("DG.Roll.Damage")})</h4>`;
     html += `     </div>`;
     html += `</div>`;
 
@@ -694,11 +690,9 @@ export class DGDamageRoll extends DGRoll {
   async toChat() {
     let label = this.formula;
     try {
-      label = `${game.i18n.localize("DG.Roll.Rolling")} <b>${game.i18n
+      label = `${_loc("DG.Roll.Rolling")} <b>${game.i18n
         .localize("DG.Roll.Damage")
-        .toUpperCase()}</b> ${game.i18n.localize("DG.Roll.For")} ${
-        this.item.name
-      } (<b>${
+        .toUpperCase()}</b> ${_loc("DG.Roll.For")} ${this.item.name} (<b>${
         this.item.system.armorPiercing
       } </b><img class="armor-piercing-chat-card-img" src="systems/deltagreen/assets/icons/supersonic-bullet.svg" alt="armor penetration"/>)`;
     } catch (ex) {
@@ -725,7 +719,7 @@ export class DGDamageRoll extends DGRoll {
       new DialogV2({
         content,
         window: {
-          title: game.i18n.localize("DG.ModifySkillRollDialogue.Title"),
+          title: _loc("DG.ModifySkillRollDialogue.Title"),
         },
         buttons: [
           {

--- a/module/settings.js
+++ b/module/settings.js
@@ -47,8 +47,8 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
       game.settings.register(DG.ID, settingID, {
         scope: "world",
         config: false,
-        name: game.i18n.localize(`DG.Settings.${settingID}.name`),
-        hint: game.i18n.localize(`DG.Settings.${settingID}.hint`),
+        name: _loc(`DG.Settings.${settingID}.name`),
+        hint: _loc(`DG.Settings.${settingID}.hint`),
         ...setting,
       });
     }
@@ -88,7 +88,7 @@ const SettingForm = class extends HandlebarsApplicationMixin(ApplicationV2) {
 
     // Once all promises resolve, show a notification.
     Promise.allSettled(settingsPromises).then((values) => {
-      ui.notifications.info(game.i18n.localize("DG.Settings.Saved"));
+      ui.notifications.info(_loc("DG.Settings.Saved"));
     });
   }
 
@@ -264,8 +264,8 @@ class HandlerSettings extends SettingForm {
 
 export default function registerSystemSettings() {
   game.settings.registerMenu(DG.ID, "automation", {
-    name: game.i18n.localize(`DG.SettingsMenu.automation.name`),
-    label: game.i18n.localize(`DG.SettingsMenu.automation.label`),
+    name: _loc(`DG.SettingsMenu.automation.name`),
+    label: _loc(`DG.SettingsMenu.automation.label`),
     hint: "",
     icon: "fa-solid fa-dice",
     type: AutomationSettings,
@@ -274,8 +274,8 @@ export default function registerSystemSettings() {
   AutomationSettings.register();
 
   game.settings.registerMenu(DG.ID, "handler", {
-    name: game.i18n.localize(`DG.SettingsMenu.handler.name`),
-    label: game.i18n.localize(`DG.SettingsMenu.handler.label`),
+    name: _loc(`DG.SettingsMenu.handler.name`),
+    label: _loc(`DG.SettingsMenu.handler.label`),
     hint: "",
     icon: "fa-solid fa-dice",
     type: HandlerSettings,
@@ -284,17 +284,17 @@ export default function registerSystemSettings() {
   HandlerSettings.register();
 
   game.settings.register("deltagreen", "characterSheetStyle", {
-    name: game.i18n.localize("DG.Settings.charactersheet.name"),
-    hint: game.i18n.localize("DG.Settings.charactersheet.hint"),
+    name: _loc("DG.Settings.charactersheet.name"),
+    hint: _loc("DG.Settings.charactersheet.hint"),
     scope: "world", // This specifies a world-stored setting
     config: true, // This specifies that the setting appears in the configuration view
     requiresReload: true,
     type: String,
     choices: {
       // If choices are defined, the resulting setting will be a select menu
-      cowboy: game.i18n.localize("DG.Settings.charactersheet.cowboys"),
-      outlaw: game.i18n.localize("DG.Settings.charactersheet.outlaws"),
-      program: game.i18n.localize("DG.Settings.charactersheet.program"),
+      cowboy: _loc("DG.Settings.charactersheet.cowboys"),
+      outlaw: _loc("DG.Settings.charactersheet.outlaws"),
+      program: _loc("DG.Settings.charactersheet.program"),
     },
     default: "program", // The default value for the setting
     onChange: (value) => {
@@ -304,8 +304,8 @@ export default function registerSystemSettings() {
   });
 
   game.settings.register("deltagreen", "sortSkills", {
-    name: game.i18n.localize("DG.Settings.sortskills.name"),
-    hint: game.i18n.localize("DG.Settings.sortskills.hint"),
+    name: _loc("DG.Settings.sortskills.name"),
+    hint: _loc("DG.Settings.sortskills.hint"),
     scope: "client",
     config: true,
     requiresReload: true,
@@ -314,17 +314,15 @@ export default function registerSystemSettings() {
   });
 
   game.settings.register("deltagreen", "skillTooltipDisplay", {
-    name: game.i18n.localize("DG.Settings.skillTooltipDisplay.name"),
-    hint: game.i18n.localize("DG.Settings.skillTooltipDisplay.hint"),
+    name: _loc("DG.Settings.skillTooltipDisplay.name"),
+    hint: _loc("DG.Settings.skillTooltipDisplay.hint"),
     scope: "client",
     config: true,
     type: String,
     choices: {
-      hover: game.i18n.localize("DG.Settings.skillTooltipDisplay.hover"),
-      never: game.i18n.localize("DG.Settings.skillTooltipDisplay.never"),
-      hoverShift: game.i18n.localize(
-        "DG.Settings.skillTooltipDisplay.hoverShift",
-      ),
+      hover: _loc("DG.Settings.skillTooltipDisplay.hover"),
+      never: _loc("DG.Settings.skillTooltipDisplay.never"),
+      hoverShift: _loc("DG.Settings.skillTooltipDisplay.hoverShift"),
     },
     default: "hover",
     onChange: () => {

--- a/module/sheets/agent-sheet.js
+++ b/module/sheets/agent-sheet.js
@@ -180,12 +180,12 @@ export default class DGAgentSheet extends DGActorSheet {
     failedTypedSkills,
   ) {
     const localizedFailedSkills = failedSkills.map((skill) =>
-      game.i18n.localize(`DG.Skills.${skill.key}`),
+      _loc(`DG.Skills.${skill.key}`),
     );
 
     const localizedFailedTypedSkills = failedTypedSkills.map((skill) => {
       const groupKey = `DG.TypeSkills.${skill.group.replace(/\s+/g, "")}`;
-      const groupLabel = game.i18n.localize(groupKey);
+      const groupLabel = _loc(groupKey);
       return `${groupLabel} (${skill.label})`;
     });
 
@@ -206,13 +206,13 @@ export default class DGAgentSheet extends DGActorSheet {
     return foundry.applications.api.DialogV2.wait({
       content,
       window: {
-        title: game.i18n.localize("DG.Skills.ApplySkillImprovements.Title"),
+        title: _loc("DG.Skills.ApplySkillImprovements.Title"),
       },
       buttons: [
         {
           default: true,
           action: "apply",
-          label: game.i18n.localize("DG.Skills.Apply"),
+          label: _loc("DG.Skills.Apply"),
           icon: "<i class='fas fa-check'></i>",
         },
       ],
@@ -276,10 +276,9 @@ export default class DGAgentSheet extends DGActorSheet {
     const localizeFailedSkills = (skillsArray) => {
       return skillsArray.map((skill) => {
         const increment = resultObj[skill.key] ?? 1;
-        const label =
-          skill.label ?? game.i18n.localize(`DG.Skills.${skill.key}`); // fallback for regular skills
+        const label = skill.label ?? _loc(`DG.Skills.${skill.key}`); // fallback for regular skills
         const groupLabel = skill.group
-          ? `${game.i18n.localize(
+          ? `${_loc(
               `DG.TypeSkills.${skill.group.replace(/\s+/g, "")}`,
             )} (${label})`
           : label;
@@ -293,12 +292,9 @@ export default class DGAgentSheet extends DGActorSheet {
 
     // Prepare chat data
     const content = [...failedSkillNames, ...failedTypedSkillNames].join(", ");
-    const flavor = game.i18n.format(
-      "DG.Skills.ApplySkillImprovements.ChatFlavor",
-      {
-        formula: DGAgentSheet._getSkillImprovementFormulaAsPercent(baseFormula),
-      },
-    );
+    const flavor = _loc("DG.Skills.ApplySkillImprovements.ChatFlavor", {
+      formula: DGAgentSheet._getSkillImprovementFormulaAsPercent(baseFormula),
+    });
 
     const chatData = {
       speaker: ChatMessage.getSpeaker({

--- a/module/sheets/base-actor-sheet.js
+++ b/module/sheets/base-actor-sheet.js
@@ -138,9 +138,7 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
     );
 
     // Set title for Physical Attributes.
-    context.physicalAttributesTitle = game.i18n.localize(
-      "DG.Sheet.BlockHeaders.Statistics",
-    );
+    context.physicalAttributesTitle = _loc("DG.Sheet.BlockHeaders.Statistics");
 
     // Whether to append the notes section to the skills.
     context.showNotesInSkills = this.actor.type !== "agent";
@@ -289,7 +287,7 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
         subnameInfoPlaceholder = "DG.AgentSheet.ProfessionPlaceholder";
         break;
     }
-    return game.i18n.localize(subnameInfoPlaceholder);
+    return _loc(subnameInfoPlaceholder);
   }
 
   /**
@@ -350,9 +348,9 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
       skill.key = key;
 
       if (game.i18n.lang === "ja") {
-        skill.sortLabel = game.i18n.localize(`DG.Skills.ruby.${key}`);
+        skill.sortLabel = _loc(`DG.Skills.ruby.${key}`);
       } else {
-        skill.sortLabel = game.i18n.localize(`DG.Skills.${key}`);
+        skill.sortLabel = _loc(`DG.Skills.${key}`);
       }
 
       if (skill.sortLabel === "" || skill.sortLabel === `DG.Skills.${key}`) {
@@ -447,11 +445,11 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
    */
   _prepareSkillTooltips() {
     for (const skill of Object.values(this.actor.system.sortedSkills)) {
-      skill.tooltip = game.i18n.localize(`DG.Skills.Tooltip.${skill.key}`);
+      skill.tooltip = _loc(`DG.Skills.Tooltip.${skill.key}`);
       if (!skill.proficiency) {
         skill.tooltip = skill.tooltip.concat(
           "<br><br>",
-          game.i18n.localize("DG.Tooltip.CannotRollSkillLabel"),
+          _loc("DG.Tooltip.CannotRollSkillLabel"),
         );
       }
     }
@@ -752,8 +750,8 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
    */
   _onItemCreate(type) {
     // Initialize a default name.
-    const name = game.i18n.format("DG.FallbackText.newItem", {
-      type: game.i18n.localize(`TYPES.Item.${type}`),
+    const name = _loc("DG.FallbackText.newItem", {
+      type: _loc(`TYPES.Item.${type}`),
     });
 
     // Prepare the item object.
@@ -1082,13 +1080,9 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
 
     // Define the option groups for our drop-down menu.
     const optionGroups = {
-      stats: game.i18n.localize(
-        "DG.SpecialTraining.Dialog.DropDown.Statistics",
-      ),
-      skills: game.i18n.localize("DG.SpecialTraining.Dialog.DropDown.Skills"),
-      typedSkills: game.i18n.localize(
-        "DG.SpecialTraining.Dialog.DropDown.CustomSkills",
-      ),
+      stats: _loc("DG.SpecialTraining.Dialog.DropDown.Statistics"),
+      skills: _loc("DG.SpecialTraining.Dialog.DropDown.Skills"),
+      typedSkills: _loc("DG.SpecialTraining.Dialog.DropDown.CustomSkills"),
     };
 
     // Prepare simplified stat list
@@ -1096,7 +1090,7 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
       ([key, stat]) => ({
         value: key,
         group: optionGroups.stats,
-        label: game.i18n.localize(`DG.Attributes.${key}`),
+        label: _loc(`DG.Attributes.${key}`),
         targetNumber: stat.value * 5,
       }),
     );
@@ -1106,7 +1100,7 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
       ([key, skill]) => ({
         value: key,
         group: optionGroups.skills,
-        label: game.i18n.localize(`DG.Skills.${key}`),
+        label: _loc(`DG.Skills.${key}`),
         targetNumber: skill.proficiency,
       }),
     );
@@ -1116,9 +1110,7 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
       ([key, skill]) => ({
         value: key,
         group: optionGroups.typedSkills,
-        label: `${game.i18n.localize(`DG.TypeSkills.${skill.group}`)} (${
-          skill.label
-        })`,
+        label: `${_loc(`DG.TypeSkills.${skill.group}`)} (${skill.label})`,
         targetNumber: skill.proficiency,
       }),
     );
@@ -1144,7 +1136,7 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
       },
     );
 
-    const buttonLabel = game.i18n.localize(
+    const buttonLabel = _loc(
       `DG.SpecialTraining.Dialog.${action.capitalize()}SpecialTraining`,
     );
 
@@ -1152,7 +1144,7 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
     new DialogV2({
       content,
       window: {
-        title: game.i18n.localize("DG.SpecialTraining.Dialog.Title"),
+        title: _loc("DG.SpecialTraining.Dialog.Title"),
       },
       default: "confirm",
       buttons: [
@@ -1348,7 +1340,7 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
           buttons: [
             {
               action: "firearms",
-              label: game.i18n.localize("DG.Gear.WeaponTypes.Firearms"),
+              label: _loc("DG.Gear.WeaponTypes.Firearms"),
               icon: '<i class="fas fa-crosshairs"></i>',
               callback: () =>
                 game.packs
@@ -1357,7 +1349,7 @@ export default class DGActorSheet extends DGSheetMixin(ActorSheetV2) {
             },
             {
               action: "melee",
-              label: game.i18n.localize("DG.Gear.WeaponTypes.Melee"),
+              label: _loc("DG.Gear.WeaponTypes.Melee"),
               icon: '<i class="far fa-hand-rock"></i>',
               callback: () =>
                 game.packs

--- a/module/sheets/npc-sheet.js
+++ b/module/sheets/npc-sheet.js
@@ -34,9 +34,7 @@ export default class DGNPCSheet extends DGActorSheet {
     const context = await super._prepareContext(options);
 
     // Override physical attribute title.
-    context.physicalAttributesTitle = game.i18n.localize(
-      "DG.Sheet.BlockHeaders.Statistics",
-    );
+    context.physicalAttributesTitle = _loc("DG.Sheet.BlockHeaders.Statistics");
 
     return context;
   }


### PR DESCRIPTION
## Checklist

* [x] This is meant for the next release.
* [ ] This is meant for a hotfix.
* [ ] This is a Build System change.
* [ ] This needs more reviewers than normal
* [ ] This intentionally introduces regressions that will be addressed later.
* [ ] The change will require updates to the documentation.
* [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

Adds `_loc` to the ESLint globals configuration so that Foundry VTT's global localization helper is recognized by ESLint and does not trigger `no-undef` errors.

## How to Test

1. Run `npm install`
2. Run `npm run lint`
3. Verify that `_loc` usages no longer produce `'_loc' is not defined` lint errors

## Related Issue(s)

Closes #413

## Future Work

Continue migrating remaining `game.i18n.localize()` and `game.i18n.format()` usages to the global `_loc()` helper where applicable.
