### PR TITLE
Update setup-node to use Node.js 24

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -5,9 +5,9 @@ runs:
   using: "composite"
   steps:
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: "22"
+        node-version: "24"
         cache: npm
 
     - name: Install dependencies


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [x] This is meant for the next release.
- [ ] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

Build failed with latest merge to master
  https://github.com/deltagreen-foundryvtt/delta-green-foundry-vtt-system/actions/runs/28748028666

Follows guidelines posted in Github changelog regarding Node 20 EoL
  https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/#what-you-need-to-do

## How to Test

CI passes

## Related Issue(s)

N/A

## Future Work

N/A
