### PR TITLE
Integrates changes from `stat-block-parser.js` into the `stat-block-macro`

### DIFF
--- a/module/macros/extract-attacks.js
+++ b/module/macros/extract-attacks.js
@@ -1,5 +1,3 @@
-const ENTRY_END = ".";
-
 const Attacks = {
   damage: "damage",
   armorPiercing: "armor piercing",

--- a/module/macros/extract-attacks.js
+++ b/module/macros/extract-attacks.js
@@ -95,8 +95,8 @@ function extractAttacksImpl(tokens, accumulatedAttacks, incompleteAttack) {
 }
 
 export function ExtractAttacks(tokens) {
-  const simplifiedTokens = tokens.filter(
-    (token) => token.replaceAll(/\(|\)/g, "") !== "or",
-  );
+  const simplifiedTokens = tokens
+    .filter((token) => token.replaceAll(/\(|\)/g, "") !== "or")
+    .filter((token) => token !== ",");
   return extractAttacksImpl(simplifiedTokens, [], { name: [] });
 }

--- a/module/macros/stat-block-parser.js
+++ b/module/macros/stat-block-parser.js
@@ -2,7 +2,12 @@ import { ExtractAttacks } from "./extract-attacks.js";
 
 const SKILL_SECTION = "skills:";
 const ATTACKS_SECTION = "attacks:";
+const COMMA = ",";
 const ENTRY_END = ".";
+// Make assumption that the following sections
+// always end in the same token
+const ARMOR_AND_EQUIPMENT_SECTION = "equipment:";
+const DISORDERS_AND_ADAPTATIONS_SECTION = "adaptations:";
 
 export const States = {
   BeginStatblock: "begin-statblock",
@@ -10,6 +15,8 @@ export const States = {
   AttributePairs: "attribute-pair",
   SkillPairs: "skill-pair",
   Attacks: "attack",
+  ArmorAndEquipment: "armor-and-equipment",
+  DisordersAndAdaptations: "disorders-and-adaptations",
   Unknown: "unknown",
 };
 
@@ -25,7 +32,8 @@ const Attributes = {
   san: "SAN",
 };
 
-const EXTRANEOUS_CHARACTERS = /%|,/g;
+const EXTRANEOUS_CHARACTERS = /%/g;
+const COMMA_MATCHER = /(.+),/g;
 const SECTION_TERMINATOR = /(.+)\./g;
 
 export function tokenize(stream) {
@@ -34,6 +42,10 @@ export function tokenize(stream) {
     .split(/\s+/)
     .flatMap((token) => {
       const strippedToken = token.replaceAll(EXTRANEOUS_CHARACTERS, "");
+      const commaMatch = COMMA_MATCHER.exec(strippedToken);
+      if (commaMatch != null) {
+        return [commaMatch[1], COMMA];
+      }
       const sectionTerminatorMatch = SECTION_TERMINATOR.exec(strippedToken);
       if (sectionTerminatorMatch !== null) {
         return [sectionTerminatorMatch[1], ENTRY_END];
@@ -80,6 +92,10 @@ export function determineNextState(token) {
       return States.SkillPairs;
     case ATTACKS_SECTION:
       return States.Attacks;
+    case DISORDERS_AND_ADAPTATIONS_SECTION:
+      return States.DisordersAndAdaptations;
+    case ARMOR_AND_EQUIPMENT_SECTION:
+      return States.ArmorAndEquipment;
     default:
       return States.Unknown;
   }
@@ -118,6 +134,14 @@ function extractSkillsImpl(tokens, skillsAccum, skillNameAccum) {
     return [skillsAccum, [maybeSkillScore, ...rest]];
   }
 
+  if (partialSkillName === COMMA) {
+    return extractSkillsImpl(
+      [maybeSkillScore, ...rest],
+      skillsAccum,
+      skillNameAccum,
+    );
+  }
+
   const skillValue = parseInt(maybeSkillScore);
   if (Number.isNaN(skillValue)) {
     return extractSkillsImpl([maybeSkillScore, ...rest], skillsAccum, [
@@ -133,12 +157,39 @@ function extractSkillsImpl(tokens, skillsAccum, skillNameAccum) {
   return extractSkillsImpl(rest, skills, []);
 }
 
+function extractArmorAndEquipmentImpl(
+  tokens,
+  armorAndEquipmentAccum,
+  equipmentAccum,
+) {
+  return [{}, []];
+}
+
+function extractDisordersAndAdaptationsImpl(
+  tokens,
+  adaptationsAccum,
+  adaptationNameAccum,
+) {
+  if (tokens === []) {
+    return [adaptationsAccum, tokens];
+  }
+  return [{}, []];
+}
+
 export function ExtractAttributes(tokens) {
   return extractAttributesImpl(tokens, { incomplete: true });
 }
 
 export function ExtractSkills(tokens) {
   return extractSkillsImpl(tokens, {}, []);
+}
+
+export function ExtractArmorAndEquipment(tokens) {
+  return extractArmorAndEquipmentImpl(tokens, {}, []);
+}
+
+export function ExtractDisordersAndAdaptations(tokens) {
+  return extractDisordersAndAdaptationsImpl(tokens, {}, []);
 }
 
 function parseStatBlockImpl(tokens, state, statBlock) {
@@ -194,6 +245,12 @@ function parseStatBlockImpl(tokens, state, statBlock) {
       ...statBlock,
       attacks,
     });
+  }
+
+  if (nextState === States.ArmorAndEquipment) {
+  }
+
+  if (nextState === States.DisordersAndAdaptations) {
   }
 
   return parseStatBlockImpl(rest, nextState, statBlock);

--- a/module/macros/stat-block-parser.js
+++ b/module/macros/stat-block-parser.js
@@ -4,6 +4,7 @@ const SKILL_SECTION = "skills:";
 const ATTACKS_SECTION = "attacks:";
 const COMMA = ",";
 const ENTRY_END = ".";
+const BREAKING = "breaking";
 // Make assumption that the following sections
 // always end in the same token
 const ARMOR_AND_EQUIPMENT_SECTION = "equipment:";
@@ -32,9 +33,16 @@ const Attributes = {
   san: "SAN",
 };
 
+const OptionalAttributes = {
+  breaking: "breaking",
+  point: "point",
+  breaking_point: "breaking_point",
+};
+
 const EXTRANEOUS_CHARACTERS = /%/g;
-const COMMA_MATCHER = /(.+),/g;
-const SECTION_TERMINATOR = /(.+)\./g;
+const COMMA_MATCHER = /(.+),/;
+const SECTION_TERMINATOR = /(.+)\./;
+const ARMOR_MATCHER = /armou?r/g;
 
 export function tokenize(stream) {
   return stream
@@ -106,15 +114,24 @@ function extractAttributesImpl(tokens, accumulator) {
     return [accumulator, tokens];
   }
 
+  const [attr, rawValue, ...rest] = tokens;
+  const value = parseInt(rawValue);
+
+  if (attr === OptionalAttributes.breaking) {
+    return extractAttributesImpl([rawValue, ...rest], accumulator);
+  }
+
+  if (attr === OptionalAttributes.point) {
+    accumulator[OptionalAttributes.breaking_point] = value;
+    return extractAttributesImpl(rest, accumulator);
+  }
+
   const currentKeys = new Set(Object.keys(accumulator));
   const expectedKeys = new Set(Object.keys(Attributes));
   if (currentKeys.intersection(expectedKeys).size === expectedKeys.size) {
     delete accumulator.incomplete;
     return [accumulator, tokens];
   }
-
-  const [attr, rawValue, ...rest] = tokens;
-  const value = parseInt(rawValue);
 
   if (Attributes[attr] == null || Number.isNaN(value)) {
     return [accumulator, tokens];
@@ -162,7 +179,56 @@ function extractArmorAndEquipmentImpl(
   armorAndEquipmentAccum,
   equipmentAccum,
 ) {
-  return [{}, []];
+  if (tokens.length === 0) {
+    return armorAndEquipmentAccum;
+  }
+
+  const [maybeArmor, ...tail] = tokens;
+
+  if (maybeArmor === COMMA && equipmentAccum.length === 0) {
+    return extractArmorAndEquipmentImpl(
+      tail,
+      armorAndEquipmentAccum,
+      equipmentAccum,
+    );
+  }
+
+  const matchesArmor = ARMOR_MATCHER.exec(maybeArmor);
+  if (matchesArmor !== null) {
+    const [maybeArmorValue, ...rest] = tail;
+    const armorName = equipmentAccum.join(" ");
+    const armorValue = parseInt(maybeArmorValue);
+    return extractArmorAndEquipmentImpl(
+      rest,
+      {
+        ...armorAndEquipmentAccum,
+        armor: {
+          name: armorName,
+          value: armorValue,
+        },
+      },
+      [],
+    );
+  }
+
+  if (maybeArmor === COMMA || tail.length === 0) {
+    const entry =
+      tail.length === 0 ? [...equipmentAccum, maybeArmor] : equipmentAccum;
+    const equipment = [...armorAndEquipmentAccum.equipment, entry.join(" ")];
+    return extractArmorAndEquipmentImpl(
+      tail,
+      {
+        ...armorAndEquipmentAccum,
+        equipment,
+      },
+      [],
+    );
+  }
+
+  return extractArmorAndEquipmentImpl(tail, armorAndEquipmentAccum, [
+    ...equipmentAccum,
+    maybeArmor,
+  ]);
 }
 
 function extractDisordersAndAdaptationsImpl(
@@ -170,10 +236,42 @@ function extractDisordersAndAdaptationsImpl(
   adaptationsAccum,
   adaptationNameAccum,
 ) {
-  if (tokens === []) {
-    return [adaptationsAccum, tokens];
+  const [maybeAdaptation, ...rest] = tokens;
+
+  if (maybeAdaptation === COMMA && adaptationNameAccum.length === 0) {
+    return extractDisordersAndAdaptationsImpl(rest, adaptationsAccum, []);
   }
-  return [{}, []];
+
+  if (tokens.length === 0) {
+    return adaptationsAccum;
+  }
+
+  if (adaptationNameAccum[0] === "adapted" && adaptationNameAccum[1] === "to") {
+    const adaptations = [...adaptationsAccum.adaptations, maybeAdaptation];
+    return extractDisordersAndAdaptationsImpl(
+      rest,
+      { ...adaptationsAccum, adaptations },
+      [],
+    );
+  }
+
+  if (maybeAdaptation === COMMA || rest.length === 0) {
+    const disorder =
+      rest.length === 0
+        ? [...adaptationNameAccum, maybeAdaptation]
+        : adaptationNameAccum;
+    const disorders = [...adaptationsAccum.disorders, disorder.join(" ")];
+    return extractDisordersAndAdaptationsImpl(
+      rest,
+      { ...adaptationsAccum, disorders },
+      [],
+    );
+  }
+
+  return extractDisordersAndAdaptationsImpl(rest, adaptationsAccum, [
+    ...adaptationNameAccum,
+    maybeAdaptation,
+  ]);
 }
 
 export function ExtractAttributes(tokens) {
@@ -185,11 +283,15 @@ export function ExtractSkills(tokens) {
 }
 
 export function ExtractArmorAndEquipment(tokens) {
-  return extractArmorAndEquipmentImpl(tokens, {}, []);
+  return extractArmorAndEquipmentImpl(tokens, { equipment: [] }, []);
 }
 
 export function ExtractDisordersAndAdaptations(tokens) {
-  return extractDisordersAndAdaptationsImpl(tokens, {}, []);
+  return extractDisordersAndAdaptationsImpl(
+    tokens,
+    { adaptations: [], disorders: [] },
+    [],
+  );
 }
 
 function parseStatBlockImpl(tokens, state, statBlock) {
@@ -248,9 +350,32 @@ function parseStatBlockImpl(tokens, state, statBlock) {
   }
 
   if (nextState === States.ArmorAndEquipment) {
+    const [armorAndEquipmentGroup, remainingTokens] =
+      groupEntriesUntilNextSection(rest);
+    const armorAndEquipment = ExtractArmorAndEquipment(
+      armorAndEquipmentGroup.flatMap((subarray, i) => {
+        if (i + 1 === armorAndEquipmentGroup.length) {
+          return subarray;
+        }
+        return [...subarray, COMMA];
+      }),
+    );
+    return parseStatBlockImpl(remainingTokens, States.Unknown, {
+      ...statBlock,
+      ...armorAndEquipment,
+    });
   }
 
   if (nextState === States.DisordersAndAdaptations) {
+    const [disordersAndAdaptationsGroup, remainingTokens] =
+      groupEntriesUntilNextSection(rest);
+    const disordersAndAdaptations = ExtractDisordersAndAdaptations(
+      disordersAndAdaptationsGroup.flatMap((subarray) => subarray),
+    );
+    return parseStatBlockImpl(remainingTokens, States.Unknown, {
+      ...statBlock,
+      ...disordersAndAdaptations,
+    });
   }
 
   return parseStatBlockImpl(rest, nextState, statBlock);

--- a/module/macros/stat-parser-macro.js
+++ b/module/macros/stat-parser-macro.js
@@ -1,4 +1,5 @@
 import { showDgDialog } from "../applications/dg-dialog.js";
+import { ParseStatBlock } from "./stat-block-parser.js";
 
 function GetAttacksFromInput(inputText) {
   const attacks = [];
@@ -294,6 +295,8 @@ async function RegexParseNpcStatBlock(inputStr, actorType) {
 
   actorData.system.health = { value: 10, min: 0, max: 10 };
   actorData.system.wp = { value: 10, min: 0, max: 10 };
+
+  const statBlock = ParseStatBlock(inputStr);
 
   let tempStr = "";
   let arr = [];

--- a/module/macros/stat-parser-macro.js
+++ b/module/macros/stat-parser-macro.js
@@ -1,140 +1,195 @@
 import { showDgDialog } from "../applications/dg-dialog.js";
 import { ParseStatBlock } from "./stat-block-parser.js";
 
-function GetAttacksFromInput(inputText) {
-  const attacks = [];
-  try {
-    // some attacks split onto multiple lines, usually separated by semicolons,
-    // try to get these back on the same line before splitting...
-    const lines = inputText
-      .replace("; \r\n", ";")
-      .replace(";\r\n", ";")
-      .replace(";\n", ";")
-      .replace("; \n", ";")
-      .split(/\r?\n/);
+const NPC_ATTRIBUTES = ["hp", "san", "wp"];
+const NPC = "npc";
+const UNNATURAL = "unnatural";
+const NPCLIKE = [NPC, UNNATURAL];
 
-    let isInAttackSection = false;
-
-    if (lines !== null && lines.length > 0) {
-      for (let i = 0; i < lines.length; i++) {
-        if (lines[i].toString().toUpperCase().indexOf("ATTACKS:") >= 0) {
-          isInAttackSection = true;
-        } else if (
-          isInAttackSection &&
-          lines[i].toString().toUpperCase().indexOf(":") > 0
-        ) {
-          isInAttackSection = false;
-        }
-
-        if (isInAttackSection) {
-          const attackLine = lines[i]
-            .toString()
-            .toUpperCase()
-            .replace("ATTACKS:", "");
-
-          console.log(attackLine);
-
-          const weaponData = {
-            type: "weapon",
-            name: "New Attack",
-            description: attackLine,
-            system: {
-              skill: "custom",
-              skillModifier: 0,
-              customSkillTarget: 0,
-              range: "0M",
-              damage: "1D10",
-              armorPiercing: 0,
-              lethality: 0,
-              isLethal: false,
-              killRadius: "N/A",
-              ammo: "N/A",
-              expense: "NA",
-              equipped: true,
-            },
-          };
-
-          // try to determine if it's a lethality attack, as those will have two % values in them
-          if (attackLine.indexOf("LETHALITY") >= 0) {
-            weaponData.isLethal = true;
-
-            const lethalityMatchStr = "(\\w.*?)(\\d\\d?%)"; // test with 'Black box 50%, Lethality 40% (see BLACK BOX).'
-            const re = new RegExp(lethalityMatchStr, "i");
-            const lethalityResults = attackLine.match(re);
-
-            if (
-              lethalityResults !== null &&
-              lethalityResults.length > 0 &&
-              lethalityResults[1] !== null &&
-              lethalityResults[1] !== undefined
-            ) {
-              weaponData.name = lethalityResults[1].toString().trim();
-
-              weaponData.lethality = parseInt(
-                lethalityResults[2]
-                  .toString()
-                  .replace("%", "")
-                  .replace(";", ""),
-              );
-            }
-          } else {
-            // assume only percent value will be the skill test associated with it
-            const skillMatchStr = `(\\w.*?)(\\d?\\d%)([\\S\\s]*?damage\\s.*?)?(\\d?d\\d?\\d?\\d([\\+\\-]\\d+)?)?`; // test with 'SIG Sauer P228 pistol 94%, damage 1D10.'
-            const re1 = new RegExp(skillMatchStr, "i");
-            const skillResults = attackLine.match(re1);
-
-            if (
-              skillResults !== null &&
-              skillResults.length > 0 &&
-              skillResults[1] !== null &&
-              skillResults[1] !== undefined
-            ) {
-              weaponData.name = skillResults[1].toString().trim();
-
-              if (
-                skillResults.length > 2 &&
-                skillResults[2] !== null &&
-                skillResults[2] !== undefined
-              ) {
-                weaponData.customSkillTarget = parseInt(
-                  skillResults[2].toString().replace("%", "").replace(";", ""),
-                );
-              }
-
-              // have to be careful, some unnatural attacks don't actually deal damage, they just grab or something.
-              // don't have a great way to indicate that in the system, so just set it to zero if we can't find it.
-              if (
-                skillResults.length > 4 &&
-                skillResults[4] !== null &&
-                skillResults[4] !== undefined
-              ) {
-                weaponData.damage = skillResults[4].toString().replace(";", "");
-              } else {
-                weaponData.damage = 0;
-              }
-            }
-
-            if (attackLine.indexOf("ARMOR PIERCING") >= 0) {
-              const apMatch = attackLine.match(/ARMOR\s+PIERCING\s*(\d+)/i);
-              const armorPiercing = apMatch?.[1] ? parseInt(apMatch[1]) : 5;
-              weaponData.armorPiercing = armorPiercing;
-              weaponData.system.armorPiercing = armorPiercing;
-            }
-          }
-
-          if (weaponData.customSkillTarget > 0 || weaponData.isLethal) {
-            attacks.push(weaponData);
-          }
-        }
-      }
-    }
-  } catch (ex) {
-    console.log("GetAttacksFromInput Error");
-    console.log(ex);
-  }
-
-  return attacks;
-}
+/**
+ * Defines the list of skills within Delta Green.
+ *
+ * Definitions:
+ * - Label:
+ *    The label that is displayed (and localized) to the end user
+ * - key:
+ *    The key that is used to assign the skill on the character sheet
+ * - typed:
+ *    Included on skills broader skills that have additional context, such
+ *    as Art, Craft or Science.
+ * - npcOnly:
+ *    Included on skils that are not available to Agents (i.e. Flying)
+ * - alternativeSpellings:
+ *    A list of one or more alternative ways the label could be spelled, such as
+ *    regional spellings (Archeology vs Archaeology). __NOTE__: For compound words
+ *    (i.e. Unarmed Combat, Melee Weapons) this list should include a lowercase spelling
+ *    of that ability (i.e. "unarmed combat")
+ *
+ * The skill map is structured as follows:
+ *
+ * ```{
+ *  Label or "Compound Label": {
+ *    key: string (required)
+ *    alternativeSpellings: List<String> (optional)
+ *    typed: boolean (optional)
+ *    npcOnly: boolean (optional)
+ *  }
+ * }
+ *
+ * */
+const SKILL_MAP = {
+  Accounting: {
+    key: "accounting",
+  },
+  Alertness: {
+    key: "alertness",
+  },
+  Anthropology: {
+    key: "anthropology",
+  },
+  Archeology: {
+    key: "archeology",
+    alternativeSpellings: ["archaeology"],
+  },
+  Art: {
+    key: "art",
+    typed: true,
+  },
+  Artillery: {
+    key: "artillery",
+  },
+  Athletics: {
+    key: "athletics",
+  },
+  Bureaucracy: {
+    key: "bureaucracy",
+  },
+  Craft: {
+    key: "craft",
+    typed: true,
+  },
+  "Computer Science": {
+    key: "computer_science",
+    alternativeSpellings: ["computer science"],
+  },
+  Criminology: {
+    key: "criminology",
+  },
+  Demolitions: {
+    key: "demolitions",
+  },
+  Disguise: {
+    key: "disguise",
+  },
+  Dodge: {
+    key: "dodge",
+  },
+  Drive: {
+    key: "drive",
+    alternativeSpellings: ["driving"],
+  },
+  Firearms: {
+    key: "firearms",
+  },
+  "First Aid": {
+    key: "first_aid",
+    alternativeSpellings: ["first aid"],
+  },
+  Flight: {
+    key: "flight",
+    npcOnly: true,
+  },
+  "Foreign Language": {
+    key: "foreign_langauge",
+    alternativeSpellings: ["foreign language"],
+    typed: true,
+  },
+  Forensics: {
+    key: "forensics",
+  },
+  "Heavy Machinery": {
+    key: "heavy_machinery",
+    alternativeSpellings: ["heavy machinery"],
+  },
+  "Heavy Weapons": {
+    key: "heavy_weapons",
+    alternativeSpellings: ["heavy weapons"],
+  },
+  History: {
+    key: "history",
+  },
+  HUMINT: {
+    key: "humint",
+  },
+  Law: {
+    key: "law",
+  },
+  Medicine: {
+    key: "medicine",
+  },
+  "Melee Weapons": {
+    key: "melee_weapons",
+    alternativeSpellings: ["melee weapons"],
+  },
+  "Military Science": {
+    key: "military_science",
+    alternativeSpellings: ["military science"],
+    typed: true,
+  },
+  "Native Language": {
+    key: "native_language",
+    alternativeSpellings: ["native language"],
+    typed: true,
+  },
+  Navigate: {
+    key: "navigate",
+  },
+  Occult: {
+    key: "occult",
+  },
+  Persuade: {
+    key: "persuade",
+  },
+  Pilot: {
+    key: "pilot",
+    typed: true,
+  },
+  Pharmacy: {
+    key: "pharmacy",
+  },
+  Psychotheraphy: {
+    key: "psychotherapy",
+  },
+  Ride: {
+    key: "ride",
+  },
+  Science: {
+    key: "science",
+    typed: true,
+  },
+  SIGINT: {
+    key: "sigint",
+  },
+  Stealth: {
+    key: "stealth",
+  },
+  Surgery: {
+    key: "surgery",
+  },
+  Survival: {
+    key: "survival",
+  },
+  Swim: {
+    key: "swim",
+  },
+  "Unarmed Combat": {
+    key: "unarmed_combat",
+    alternativeSpellings: ["unarmed combat"],
+  },
+  Unnatural: {
+    key: "unnatural",
+  },
+};
 
 function GetNotesFromInput(inputText) {
   const matchStr = "(?:ATTACKS:[\\S\\s]*?\\.\\n)([\\S\\s]*)";
@@ -160,54 +215,6 @@ function GetNotesFromInput(inputText) {
   }
 
   return [notes];
-}
-
-function GetArmorFromInput(inputText) {
-  try {
-    const armor = { name: "Armor", description: "", armor: 0 };
-
-    const lines = inputText.split(/\r?\n/);
-
-    if (lines !== null && lines.length > 0) {
-      for (let i = 0; i < lines.length; i++) {
-        if (lines[i].toString().toUpperCase().indexOf("ARMOR:") >= 0) {
-          armor.description = lines[i]
-            .replace("Armor:", "")
-            .replace("ARMOR:", "")
-            .trim();
-
-          const matchStr = `(\\d\\d?)`;
-          const re = new RegExp(matchStr, "i");
-          const results = lines[i].match(re);
-
-          try {
-            if (results != null && results.length > 0) {
-              armor.armor = parseInt(results[0]);
-
-              armor.name = armor.description
-                .replace(`(Armor ${armor.armor})`, "")
-                .trim();
-
-              armor.name = armor.name
-                .replace(`${armor.armor} points of`, "")
-                .replace(`${armor.armor} point of`, "")
-                .replace(".", "")
-                .trim();
-            }
-          } catch (ex) {
-            console.log("GetArmorFromInput Error");
-            console.log(ex);
-          }
-
-          return armor;
-        }
-      }
-    }
-  } catch (ex) {
-    console.log("GetArmorFromInput Error");
-    console.log(ex);
-  }
-  return null;
 }
 
 // this is the main stat call, it's exposed as part of the system itself for users to access
@@ -243,26 +250,6 @@ function GetTypeSkillRatingsFromInput(inputText) {
   return matches;
 }
 
-function GetAttributeFromInput(inputText, attribute) {
-  const matchStr = `(?:${attribute}\\s)(\\d\\d?)`;
-  const re = new RegExp(matchStr, "i");
-  const results = inputText.match(re);
-  let attributeScore = 10;
-
-  try {
-    if (results != null && results.length > 1) {
-      attributeScore = parseInt(results[1]);
-    } else {
-      attributeScore = 0;
-    }
-  } catch (ex) {
-    console.log("GetAttributeFromInput Error");
-    console.log(ex);
-  }
-
-  return attributeScore;
-}
-
 function GetSkillRatingsFromInput(inputText, skill) {
   const matchStr = `(?:${skill}\\n?\\s?\\n?)(\\d\\d?)`;
   const re = new RegExp(matchStr, "i");
@@ -283,8 +270,8 @@ function GetSkillRatingsFromInput(inputText, skill) {
 
 async function RegexParseNpcStatBlock(inputStr, actorType) {
   const actorData = {};
-
-  let shortDescription = "";
+  const isNpcLike = NPCLIKE.includes(actorType);
+  const statBlock = ParseStatBlock(inputStr);
 
   actorData.type = actorType;
   actorData.system = {};
@@ -296,95 +283,66 @@ async function RegexParseNpcStatBlock(inputStr, actorType) {
   actorData.system.health = { value: 10, min: 0, max: 10 };
   actorData.system.wp = { value: 10, min: 0, max: 10 };
 
-  const statBlock = ParseStatBlock(inputStr);
+  actorData.name = statBlock.name;
+  actorData.system.physical = {
+    description: "",
+  };
 
-  let tempStr = "";
-  let arr = [];
-
-  tempStr = inputStr.split(/\r?\n/);
-
-  if (tempStr.length > 0) {
-    [actorData.name] = tempStr;
-
-    // set the alternate description/profession/etc.
-    // if this doesn't exist, the next line should be the attributes starting with strength
-    // so if the second line starts with "STR" then just leave it be.
-    if (
-      tempStr.length > 1 &&
-      tempStr[1].substring(0, 3) !== "STR" &&
-      tempStr[1].substring(0, 3) !== "CON" &&
-      tempStr[1].substring(0, 3) !== "DEX" &&
-      tempStr[1].substring(0, 3) !== "INT" &&
-      tempStr[1].substring(0, 3) !== "POW" &&
-      tempStr[1].substring(0, 3) !== "CHA"
-    ) {
-      [, shortDescription] = tempStr;
-    }
-  } else {
-    actorData.name = "Unknown";
-  }
-
-  const armor = GetArmorFromInput(inputStr);
-
-  const attacks = GetAttacksFromInput(inputStr);
-
-  if (armor !== null) {
-    console.log(armor);
-  }
-
-  if (actorType === "agent") {
+  if (!isNpcLike) {
     actorData.system.physical = {
-      description: shortDescription,
+      ...actorData.system.physical,
       wounds: "",
       firstAidAttempted: false,
     };
-  } else if (actorType === "npc" || actorType === "unnatural") {
-    actorData.system.shortDescription = shortDescription;
   }
 
-  actorData.system.statistics.str = {
-    value: GetAttributeFromInput(inputStr, "STR"),
-    distinguishing_feature: "",
-  };
-  actorData.system.statistics.con = {
-    value: GetAttributeFromInput(inputStr, "CON"),
-    distinguishing_feature: "",
-  };
-  actorData.system.statistics.dex = {
-    value: GetAttributeFromInput(inputStr, "DEX"),
-    distinguishing_feature: "",
-  };
-  actorData.system.statistics.int = {
-    value: GetAttributeFromInput(inputStr, "INT"),
-    distinguishing_feature: "",
-  };
-  actorData.system.statistics.pow = {
-    value: GetAttributeFromInput(inputStr, "POW"),
-    distinguishing_feature: "",
-  };
-  actorData.system.statistics.cha = {
-    value: GetAttributeFromInput(inputStr, "CHA"),
-    distinguishing_feature: "",
-  };
+  const { attributes } = statBlock;
+  Object.entries(attributes).forEach(([key, value]) => {
+    if (isNpcLike && NPC_ATTRIBUTES.includes(key) === false) {
+      actorData.system.statistics[key] = {
+        value,
+        distinguishing_feature: "",
+      };
 
-  if (actorType === "npc" || actorType === "unnatural") {
-    // don't want to try to set HP/SAN for player characters
-    actorData.system.health = {
-      min: 0,
-      max: GetAttributeFromInput(inputStr, "HP"),
-      value: GetAttributeFromInput(inputStr, "HP"),
-    };
-    actorData.system.sanity = {
-      max: actorData.system.statistics.pow.value * 5,
-      value: GetAttributeFromInput(inputStr, "SAN"),
-      currentBreakingPoint: GetAttributeFromInput(inputStr, "BREAKING POINT"),
-    };
-    actorData.system.wp = {
-      max: actorData.system.statistics.pow.value,
-      value: GetAttributeFromInput(inputStr, "WP"),
-      min: 0,
-    };
-  }
+      return;
+    }
+
+    if (key === "hp") {
+      actorData.system.health = {
+        value,
+        min: 0,
+        max: value,
+      };
+
+      return;
+    }
+
+    if (key === "san") {
+      actorData.system.sanity = {
+        value,
+        currentBreakingPoint: attributes.breaking_point,
+        max: attributes.pow * 5,
+      };
+
+      return;
+    }
+
+    if (key === "wp") {
+      actorData.system.wp = {
+        value,
+        min: 0,
+        max: attributes.pow,
+      };
+    }
+  });
+
+  const { skills } = statBlock;
+  Object.entries(SKILL_MAP).forEach(([label, skillInfo]) => {
+    if (skillInfo.npcOnly && !isNpcLike) return;
+
+    if (skillInfo.typed) {
+    }
+  });
 
   actorData.system.skills.accounting = {
     label: "Accounting",

--- a/module/macros/stat-parser-macro.js
+++ b/module/macros/stat-parser-macro.js
@@ -191,6 +191,37 @@ const SKILL_MAP = {
   },
 };
 
+function findSkillScore({ key, alternativeSpellings }, skills) {
+  if (skills[key]) return skills[key];
+  if (alternativeSpellings === undefined) return null;
+
+  for (let i = 0; i < alternativeSpellings.length; i++) {
+    const alternateName = alternativeSpellings[i];
+    if (skills[alternateName]) return skills[alternateName];
+  }
+
+  return null;
+}
+
+/**
+ *
+ * @param {Object} skillDefinition - Map containing key (string) and alternativeSpellings (list)
+ * @param {Object} skills - Map of character skills
+ * @returns List of typed Skill names that match the skill definition
+ */
+function findRelevantTypedSkills({ key, alternativeSpellings }, skills) {
+  return Object.keys(skills).filter((skill) => {
+    if (skill.includes(key)) return true;
+    return (alternativeSpellings || []).some((altSpelling) =>
+      skill.includes(altSpelling),
+    );
+  });
+}
+
+function normalizeTypedSkill(name) {
+  name.replace(/\s+/, "_").replace(/\(|\)/, "");
+}
+
 function GetNotesFromInput(inputText) {
   const matchStr = "(?:ATTACKS:[\\S\\s]*?\\.\\n)([\\S\\s]*)";
   const re = new RegExp(matchStr, "gi");
@@ -215,57 +246,6 @@ function GetNotesFromInput(inputText) {
   }
 
   return [notes];
-}
-
-// this is the main stat call, it's exposed as part of the system itself for users to access
-// call this within a world as: game.deltagreen.ParseDeltaGreenStatBlock()
-function GetTypeSkillRatingsFromInput(inputText) {
-  const matchStr =
-    "(Art|Craft|Foreign Language|Native Language|Military Science|Pilot|Science)\\s?\\((\\w.*?)\\)\\s?(\\d?\\d)%";
-
-  inputText = inputText.replace(/[\n\r]/g, " ");
-
-  const re = new RegExp(matchStr, "gi");
-
-  const matches = [];
-  let match;
-
-  try {
-    // This is probably one of the few times where its recommended to assign within a while loop.
-    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec
-    // eslint-disable-next-line no-cond-assign
-    while ((match = re.exec(inputText))) {
-      matches.push({
-        group: match[1],
-        label: match[2],
-        proficiency: parseInt(match[3]),
-        failure: false,
-      });
-    }
-  } catch (ex) {
-    console.log("GetAttributeFromInput Error");
-    console.log(ex);
-  }
-
-  return matches;
-}
-
-function GetSkillRatingsFromInput(inputText, skill) {
-  const matchStr = `(?:${skill}\\n?\\s?\\n?)(\\d\\d?)`;
-  const re = new RegExp(matchStr, "i");
-  const results = inputText.match(re);
-  let skillValue = 0;
-
-  try {
-    if (results != null && results.length > 1) {
-      skillValue = parseInt(results[1]);
-    }
-  } catch (ex) {
-    console.log("GetAttributeFromInput Error");
-    console.log(ex);
-  }
-
-  return skillValue;
 }
 
 async function RegexParseNpcStatBlock(inputStr, actorType) {
@@ -340,265 +320,73 @@ async function RegexParseNpcStatBlock(inputStr, actorType) {
   Object.entries(SKILL_MAP).forEach(([label, skillInfo]) => {
     if (skillInfo.npcOnly && !isNpcLike) return;
 
+    const proficiency = findSkillScore(skillInfo, skills);
+    if (!proficiency) return;
     if (skillInfo.typed) {
+      findRelevantTypedSkills(skillInfo, skills).forEach((skillName) => {
+        const typedSkillKey = normalizeTypedSkill(skillName);
+        const typedSkillProficiency = findSkillScore(
+          { key: skillName },
+          skills,
+        );
+        actorData.system.typedSkills[typedSkillKey] = {
+          label: skillName,
+          proficiency: typedSkillProficiency,
+          failure: false,
+        };
+      });
+
+      return;
     }
+
+    actorData.system.skills[skillInfo.key] = {
+      label,
+      proficiency,
+      failure: false,
+    };
   });
-
-  actorData.system.skills.accounting = {
-    label: "Accounting",
-    proficiency: GetSkillRatingsFromInput(inputStr, "ACCOUNTING"),
-    failure: false,
-  };
-  actorData.system.skills.alertness = {
-    label: "Alertness",
-    proficiency: GetSkillRatingsFromInput(inputStr, "ALERTNESS"),
-    failure: false,
-  };
-  actorData.system.skills.anthropology = {
-    label: "Anthropology",
-    proficiency: GetSkillRatingsFromInput(inputStr, "ANTHROPOLOGY"),
-    failure: false,
-  };
-  actorData.system.skills.archeology = {
-    label: "Archeology",
-    proficiency: GetSkillRatingsFromInput(inputStr, "ARCHEOLOGY|ARCHAEOLOGY"),
-    failure: false,
-  }; // damn you british spellings
-  actorData.system.skills.artillery = {
-    label: "Artillery",
-    proficiency: GetSkillRatingsFromInput(inputStr, "ARTILLERY"),
-    failure: false,
-  };
-  actorData.system.skills.athletics = {
-    label: "Athletics",
-    proficiency: GetSkillRatingsFromInput(inputStr, "ATHLETICS"),
-    failure: false,
-  };
-  actorData.system.skills.bureaucracy = {
-    label: "Bureaucracy",
-    proficiency: GetSkillRatingsFromInput(inputStr, "BUREAUCRACY"),
-    failure: false,
-  };
-  actorData.system.skills.computer_science = {
-    label: "Computer Science",
-    proficiency: GetSkillRatingsFromInput(inputStr, "COMPUTER SCIENCE"),
-    failure: false,
-  };
-  actorData.system.skills.criminology = {
-    label: "Criminology",
-    proficiency: GetSkillRatingsFromInput(inputStr, "CRIMINOLOGY"),
-    failure: false,
-  };
-  actorData.system.skills.demolitions = {
-    label: "Demolitions",
-    proficiency: GetSkillRatingsFromInput(inputStr, "DEMOLITIONS"),
-    failure: false,
-  };
-  actorData.system.skills.disguise = {
-    label: "Disguise",
-    proficiency: GetSkillRatingsFromInput(inputStr, "DISGUISE"),
-    failure: false,
-  };
-  actorData.system.skills.dodge = {
-    label: "Dodge",
-    proficiency: GetSkillRatingsFromInput(inputStr, "DODGE"),
-    failure: false,
-  };
-  actorData.system.skills.drive = {
-    label: "Drive",
-    proficiency: GetSkillRatingsFromInput(inputStr, "DRIVE"),
-    failure: false,
-  };
-
-  // Impossible Landscapes seems to favor 'Driving' as the name for this instead for some reason
-  if (actorData.system.skills.drive.proficiency === 0) {
-    actorData.system.skills.drive = {
-      label: "Drive",
-      proficiency: GetSkillRatingsFromInput(inputStr, "DRIVING"),
-      failure: false,
-    };
-  }
-
-  actorData.system.skills.firearms = {
-    label: "Firearms",
-    proficiency: GetSkillRatingsFromInput(inputStr, "FIREARMS"),
-    failure: false,
-  };
-  actorData.system.skills.first_aid = {
-    label: "First Aid",
-    proficiency: GetSkillRatingsFromInput(inputStr, "FIRST AID"),
-    failure: false,
-  };
-  actorData.system.skills.forensics = {
-    label: "Forensics",
-    proficiency: GetSkillRatingsFromInput(inputStr, "FORENSICS"),
-    failure: false,
-  };
-  actorData.system.skills.heavy_machinery = {
-    label: "Heavy Machinery",
-    proficiency: GetSkillRatingsFromInput(inputStr, "HEAVY MACHINERY"),
-    failure: false,
-  }; // template.json has typo on heavy machinery...
-  actorData.system.skills.heavy_weapons = {
-    label: "Heavy Weapons",
-    proficiency: GetSkillRatingsFromInput(inputStr, "HEAVY WEAPONS"),
-    failure: false,
-  };
-  actorData.system.skills.history = {
-    label: "History",
-    proficiency: GetSkillRatingsFromInput(inputStr, "HISTORY"),
-    failure: false,
-  };
-  actorData.system.skills.humint = {
-    label: "HUMINT",
-    proficiency: GetSkillRatingsFromInput(inputStr, "HUMINT"),
-    failure: false,
-  };
-  actorData.system.skills.law = {
-    label: "Law",
-    proficiency: GetSkillRatingsFromInput(inputStr, "LAW"),
-    failure: false,
-  };
-  actorData.system.skills.medicine = {
-    label: "Medicine",
-    proficiency: GetSkillRatingsFromInput(inputStr, "MEDICINE"),
-    failure: false,
-  };
-  actorData.system.skills.melee_weapons = {
-    label: "Melee Weapons",
-    proficiency: GetSkillRatingsFromInput(inputStr, "MELEE WEAPONS"),
-    failure: false,
-  };
-  actorData.system.skills.navigate = {
-    label: "Navigate",
-    proficiency: GetSkillRatingsFromInput(inputStr, "NAVIGATE"),
-    failure: false,
-  };
-  actorData.system.skills.occult = {
-    label: "Occult",
-    proficiency: GetSkillRatingsFromInput(inputStr, "OCCULT"),
-    failure: false,
-  };
-  actorData.system.skills.persuade = {
-    label: "Persuade",
-    proficiency: GetSkillRatingsFromInput(inputStr, "PERSUADE"),
-    failure: false,
-  };
-  actorData.system.skills.pharmacy = {
-    label: "Pharmacy",
-    proficiency: GetSkillRatingsFromInput(inputStr, "PHARMACY"),
-    failure: false,
-  };
-  actorData.system.skills.psychotherapy = {
-    label: "Psychotherapy",
-    proficiency: GetSkillRatingsFromInput(inputStr, "PSYCHOTHERAPY"),
-    failure: false,
-  };
-  actorData.system.skills.ride = {
-    label: "Ride",
-    proficiency: GetSkillRatingsFromInput(inputStr, "RIDE"),
-    failure: false,
-  };
-  actorData.system.skills.search = {
-    label: "Search",
-    proficiency: GetSkillRatingsFromInput(inputStr, "SEARCH"),
-    failure: false,
-  };
-  actorData.system.skills.sigint = {
-    label: "SIGINT",
-    proficiency: GetSkillRatingsFromInput(inputStr, "SIGINT"),
-    failure: false,
-  };
-  actorData.system.skills.stealth = {
-    label: "Stealth",
-    proficiency: GetSkillRatingsFromInput(inputStr, "STEALTH"),
-    failure: false,
-  };
-  actorData.system.skills.surgery = {
-    label: "Surgery",
-    proficiency: GetSkillRatingsFromInput(inputStr, "SURGERY"),
-    failure: false,
-  };
-  actorData.system.skills.survival = {
-    label: "Survival",
-    proficiency: GetSkillRatingsFromInput(inputStr, "SURVIVAL"),
-    failure: false,
-  };
-  actorData.system.skills.swim = {
-    label: "Swim",
-    proficiency: GetSkillRatingsFromInput(inputStr, "SWIM"),
-    failure: false,
-  };
-  actorData.system.skills.unarmed_combat = {
-    label: "Unarmed Combat",
-    proficiency: GetSkillRatingsFromInput(inputStr, "UNARMED COMBAT"),
-    failure: false,
-  };
-  actorData.system.skills.unnatural = {
-    label: "Unnatural",
-    proficiency: GetSkillRatingsFromInput(inputStr, "UNNATURAL"),
-    failure: false,
-  };
-
-  // some npcs/unnatural have other skills
-  if (GetSkillRatingsFromInput(inputStr, "FLIGHT") > 0) {
-    actorData.system.skills.flight = {
-      label: "Flight",
-      proficiency: GetSkillRatingsFromInput(inputStr, "FLIGHT"),
-      failure: false,
-    };
-  }
-
-  arr = GetTypeSkillRatingsFromInput(inputStr);
-
-  for (let index = 0; index < arr.length; index += 1) {
-    const element = arr[index];
-    actorData.system.typedSkills[`tskill_${index.toString()}`] = element;
-  }
 
   if (actorType === "npc" || actorType === "unnatural") {
     actorData.system.notes = GetNotesFromInput(inputStr);
   }
 
-  console.log(actorData);
+  const [newActor] = await Actor.createDocuments([actorData]);
+  const { armor, attacks } = statBlock;
 
-  const newActors = await Actor.createDocuments([actorData]);
+  if (armor) {
+    await newActor.AddArmorItemToSheet(armor.name, "", armor.value, true);
+  }
 
-  if (armor !== null) {
-    if (armor.description === null || armor.description.trim() === "") {
-      armor.description = "Armor";
-    }
-
-    await newActors[0].AddArmorItemToSheet(
-      armor.name,
-      armor.description,
-      armor.armor,
-      true,
+  (attacks || []).forEach(async (attack) => {
+    const { name, skillModifier, damage, armorPiercing, lethality } = attack;
+    const [description, attackSkill, killRadius, expense] = [
+      "",
+      "custom",
+      "N/A",
+      "N/A",
+    ];
+    const [range, skillMod] = [0, 0];
+    const skillTarget = skillModifier;
+    const equipped = true;
+    const isLethal = damage === undefined && lethality !== undefined;
+    await newActor.AddWeaponItemToSheet(
+      name,
+      description,
+      damage,
+      attackSkill,
+      skillMod,
+      skillTarget,
+      armorPiercing,
+      lethality,
+      isLethal,
+      range,
+      killRadius,
+      expense,
+      equipped,
     );
-  }
+  });
 
-  if (attacks !== null && attacks.length > 0) {
-    for (const a of attacks) {
-      await newActors[0].AddWeaponItemToSheet(
-        a.name,
-        a.description,
-        a.damage,
-        a.skill,
-        a.skillModifier,
-        a.customSkillTarget,
-        a.armorPiercing,
-        a.lethality,
-        a.isLethal,
-        a.range,
-        a.killRadius,
-        a.ammo,
-        a.expense,
-        a.equipped,
-      );
-    }
-  }
-
-  newActors[0].sheet.render(true);
+  newActor.sheet.render(true);
 }
 
 async function GetUserInput() {

--- a/test/macros/extract-attacks.test.js
+++ b/test/macros/extract-attacks.test.js
@@ -6,7 +6,7 @@ import {
 
 const assaultRifleEntry = {
   input:
-    "assault rifle 45 damage 1d12+1 (or lethality 10) armor piercing 3".split(
+    "assault rifle 45 , damage 1d12+1 (or lethality 10) armor piercing 3".split(
       " ",
     ),
   expectedAttacks: [
@@ -21,7 +21,7 @@ const assaultRifleEntry = {
   expectedTokensRemaining: [],
 };
 const heavyRifleEntry = {
-  input: "heavy rifle 45 damage 1d12+2 armor piercing 3".split(" "),
+  input: "heavy rifle 45 , damage 1d12+2 armor piercing 3".split(" "),
   expectedAttacks: [
     {
       name: "Heavy Rifle",
@@ -33,7 +33,7 @@ const heavyRifleEntry = {
   expectedTokensRemaining: [],
 };
 const meleeWeaponEntry = {
-  input: "big knife 50 damage 1d8".split(" "),
+  input: "big knife 50 , damage 1d8".split(" "),
   expectedAttacks: [
     {
       name: "Big Knife",
@@ -44,7 +44,7 @@ const meleeWeaponEntry = {
   expectedTokensRemaining: [],
 };
 const handGrenadeEntry = {
-  input: "hand grenade 50 lethality 15".split(" "),
+  input: "hand grenade 50 , lethality 15".split(" "),
   expectedAttacks: [
     {
       name: "Hand Grenade",
@@ -55,7 +55,7 @@ const handGrenadeEntry = {
   expectedTokensRemaining: [],
 };
 const complexLethality = {
-  input: "danger stick 55 lethality 2 or 15 or 25 (see dangerous)".split(" "),
+  input: "danger stick 55 , lethality 2 or 15 or 25 (see dangerous)".split(" "),
   expectedAttacks: [
     {
       name: "Danger Stick",

--- a/test/macros/stat-block-parser.test.js
+++ b/test/macros/stat-block-parser.test.js
@@ -4,6 +4,8 @@ import fs from "node:fs";
 import {
   ExtractAttributes,
   ExtractSkills,
+  ExtractArmorAndEquipment,
+  ExtractDisordersAndAdaptations,
   tokenize,
   determineNextState,
   groupEntriesUntilNextSection,
@@ -63,12 +65,15 @@ describe("tokenize", () => {
     "skills:",
     "firearms",
     "45",
+    ",",
     "heavy",
     "weapons",
     "50",
+    ",",
     "melee",
     "weapons",
     "75",
+    ",",
     "science",
     "(biology)",
     "50",
@@ -191,6 +196,69 @@ describe("ExtractSkills", () => {
   });
 });
 
+describe("ExtractArmorAndEquipment", () => {
+  test.each([
+    {
+      testName: "correctly extracts armor information and equipment list",
+      input:
+        "advanced kevlar vest (armor 4), three extra pistol magazines, flashlight, nightvision goggles",
+      expected: {
+        armor: {
+          name: "Advanced Kevlar Vest",
+          value: 4,
+        },
+        equipment: [
+          "three extra pistol magazines",
+          "flashlight",
+          "nightvision goggles",
+        ],
+      },
+    },
+  ])(".ExtractArmorAndEquipment() on $testName", ({ input, expected }) => {
+    const tokens = tokenize(input);
+    const [result, rest] = ExtractArmorAndEquipment(tokens);
+    expect(rest).toEqual([]);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("ExtractDisordersAndAdaptations", () => {
+  test.each([
+    {
+      testName: "correctly extracts disorders",
+      input: "intermittent explosive disorder, cocaine addiction",
+      expected: {
+        disorders: ["intermittent explosive disorder", "cocaine addiction"],
+      },
+    },
+    {
+      testName: "correctly extracts adaptations",
+      input: "adapted to violence, adapted to helplessness",
+      expected: {
+        adaptations: ["violence", "helplessness"],
+      },
+    },
+    {
+      testName:
+        "correctly extract adaptations and disorders, regardless of where they are",
+      input:
+        "cocaine addiction, adapted to violence, intermittent explosive disorder, adapted to helplessness",
+      expected: {
+        adaptations: ["violence", "helplessness"],
+        disorders: ["cocaine addiction", "intermittent explosive disorder"],
+      },
+    },
+  ])(
+    ".ExtractDisordersAndAdaptations() on $testName",
+    ({ input, expected }) => {
+      const tokens = tokenize(input);
+      const [result, rest] = ExtractDisordersAndAdaptations(tokens);
+      expect(rest).toEqual([]);
+      expect(result).toEqual(expected);
+    },
+  );
+});
+
 describe("ParseStatBlock", () => {
   const readStatblock = (name) =>
     fs.readFileSync(`${__dirname}/statblocks/${name}.txt`, "utf8");
@@ -238,6 +306,78 @@ describe("ParseStatBlock", () => {
             name: "Big Knife",
             skillModifier: 50,
             damage: "1d8",
+            notes: "",
+          },
+        ],
+      },
+    },
+    {
+      testName: "Parsing a complex NPC statblock",
+      input: readStatblock("complex-stats"),
+      expected: {
+        name: "private military contractor",
+        attributes: {
+          str: 14,
+          con: 13,
+          dex: 12,
+          int: 11,
+          pow: 12,
+          cha: 7,
+          hp: 14,
+          wp: 10,
+          san: 53,
+          breaking_point: 48,
+        },
+        armor: {
+          name: "Advanced Kevlar Vest",
+          value: 4,
+        },
+        adaptations: ["violence"],
+        disorders: [],
+        skills: {
+          alertness: 60,
+          athletics: 50,
+          dodge: 40,
+          driving: 40,
+          firearms: 60,
+          humint: 40,
+          law: 30,
+          "melee weapons": 50,
+          persuade: 40,
+          search: 50,
+          "unarmed combat": 60,
+        },
+        equipment: [
+          "three extra pistol magazines",
+          "flashlight",
+          "nightvision goggles",
+          "a dozen cable ties (for use as plastic handcuffs)",
+          "the carbines are stored in a secure locker, not usually carried",
+        ],
+        attacks: [
+          {
+            name: "Medium Pistol",
+            skillModifier: 60,
+            damage: "1d10",
+            notes: "",
+          },
+          {
+            name: "Carbine",
+            skillModifier: 60,
+            damage: "1d12",
+            armorPiercing: 3,
+            notes: "",
+          },
+          {
+            name: "Baton",
+            skillModifier: 50,
+            damage: "1d6+1",
+            notes: "",
+          },
+          {
+            name: "Unarmed",
+            skillModifier: 60,
+            damage: "1d4",
             notes: "",
           },
         ],

--- a/test/macros/stat-block-parser.test.js
+++ b/test/macros/stat-block-parser.test.js
@@ -201,10 +201,10 @@ describe("ExtractArmorAndEquipment", () => {
     {
       testName: "correctly extracts armor information and equipment list",
       input:
-        "advanced kevlar vest (armor 4), three extra pistol magazines, flashlight, nightvision goggles",
+        "advanced kevlar vest armor 4, three extra pistol magazines, flashlight , nightvision goggles",
       expected: {
         armor: {
-          name: "Advanced Kevlar Vest",
+          name: "advanced kevlar vest",
           value: 4,
         },
         equipment: [
@@ -216,8 +216,7 @@ describe("ExtractArmorAndEquipment", () => {
     },
   ])(".ExtractArmorAndEquipment() on $testName", ({ input, expected }) => {
     const tokens = tokenize(input);
-    const [result, rest] = ExtractArmorAndEquipment(tokens);
-    expect(rest).toEqual([]);
+    const result = ExtractArmorAndEquipment(tokens);
     expect(result).toEqual(expected);
   });
 });
@@ -228,6 +227,7 @@ describe("ExtractDisordersAndAdaptations", () => {
       testName: "correctly extracts disorders",
       input: "intermittent explosive disorder, cocaine addiction",
       expected: {
+        adaptations: [],
         disorders: ["intermittent explosive disorder", "cocaine addiction"],
       },
     },
@@ -236,6 +236,7 @@ describe("ExtractDisordersAndAdaptations", () => {
       input: "adapted to violence, adapted to helplessness",
       expected: {
         adaptations: ["violence", "helplessness"],
+        disorders: [],
       },
     },
     {
@@ -252,8 +253,7 @@ describe("ExtractDisordersAndAdaptations", () => {
     ".ExtractDisordersAndAdaptations() on $testName",
     ({ input, expected }) => {
       const tokens = tokenize(input);
-      const [result, rest] = ExtractDisordersAndAdaptations(tokens);
-      expect(rest).toEqual([]);
+      const result = ExtractDisordersAndAdaptations(tokens);
       expect(result).toEqual(expected);
     },
   );
@@ -329,7 +329,7 @@ describe("ParseStatBlock", () => {
           breaking_point: 48,
         },
         armor: {
-          name: "Advanced Kevlar Vest",
+          name: "advanced kevlar vest",
           value: 4,
         },
         adaptations: ["violence"],
@@ -352,7 +352,8 @@ describe("ParseStatBlock", () => {
           "flashlight",
           "nightvision goggles",
           "a dozen cable ties (for use as plastic handcuffs)",
-          "the carbines are stored in a secure locker, not usually carried",
+          "the carbines are stored in a secured locker",
+          "not usually carried",
         ],
         attacks: [
           {

--- a/test/macros/statblocks/complex-stats.txt
+++ b/test/macros/statblocks/complex-stats.txt
@@ -10,6 +10,6 @@ Carbine 60%, damage 1D12, Armor Piercing 3.
 Baton 50%, damage 1D6+1.
 Unarmed 60%, damage 1D4.
 ARMOR AND EQUIPMENT: Advanced kevlar vest (Armor 4), three
-extra pistol magazines, flashlight, night­vision goggles, a dozen
+extra pistol magazines, flashlight, nightvision goggles, a dozen
 cable ties (for use as plastic handcuffs). The carbines are stored
 in a secured locker, not usually carried.

--- a/test/macros/statblocks/complex-stats.txt
+++ b/test/macros/statblocks/complex-stats.txt
@@ -1,0 +1,15 @@
+Private Military Contractor
+STR 14 CON 13 DEX 12 INT 11 POW 12 CHA 7
+HP 14 WP 10 SAN 53 BREAKING POINT 48
+DISORDERS AND ADAPTATIONS: Adapted to violence.
+SKILLS: Alertness 60%, Athletics 50%, Dodge 40%, Driving
+40%, Firearms 60%, HUMINT 40%, Law 30%, Melee Weapons
+50%, Persuade 40%, Search 50%, Unarmed Combat 60%.
+ATTACKS: Medium Pistol 60%, damage 1D10.
+Carbine 60%, damage 1D12, Armor Piercing 3.
+Baton 50%, damage 1D6+1.
+Unarmed 60%, damage 1D4.
+ARMOR AND EQUIPMENT: Advanced kevlar vest (Armor 4), three
+extra pistol magazines, flashlight, night­vision goggles, a dozen
+cable ties (for use as plastic handcuffs). The carbines are stored
+in a secured locker, not usually carried.


### PR DESCRIPTION
Refactors the Stat block macro to use the new parser. Also adds extra functionality to the stat block parser to address features that were missing (extracting armor).

Also adds support for the following to the parser:
- Disorders and Adaptations
- Equipment -- to an extent. This section is very difficult to parse and trying to make it perfect sounds like a fools errand.

Character sheets do not get updated with disorders, adaptations or equipment. Those will be supported via separate tickets.

## Checklist

<!-- Check one or more: -->

- [x] This is meant for the next release.
- [ ] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

<!-- Briefly describe the purpose of the PR and what it changes. -->

## How to Test

1. On the Actors panel, click the "Delta Green Stat Block Parser" at the bottom
2. Paste in a character stat block from a Delta Green operation.
3. Click the Parse buton


## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #231 

## Future Work

<!-- Describe any follow-up work, improvements, or additional features related to this PR. -->
