### PR TITLE
Add Damage and Lethality buttons to chat entries

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -550,6 +550,8 @@
   "DG.SettingsMenu.handler.name": "Handler Settings",
   "DG.SettingsMenu.handler.label": "Handler Settings",
   "DG.SettingsMenu.handler.title": "Handler-only Settings",
+  "DG.Messages.RollDamage": "Damage Roll",
+  "DG.Messages.RollLethality": "Lethality Roll",
   "DG.Messages.Skillsmark.Marked": "This skill is marked",
   "DG.Messages.Skillsmark.Tooltip": "See p. 29 Agent's Handbook",
   "DG.Profession.Dialog.OptionPicksRequired": "Select exactly {picks} skill option(s).",

--- a/module/chat/dg-chat-card.js
+++ b/module/chat/dg-chat-card.js
@@ -217,6 +217,17 @@ export function enrichDGChatCardMessage(message, element) {
     header.appendChild(metadataSlot);
   }
 
+  const applyDamage = card.querySelector(".dg-result-actions");
+  if (applyDamage) {
+    applyDamage.querySelectorAll("[data-action]").forEach((damageButton) => {
+      damageButton.addEventListener("click", async () => {
+        const item = await foundry.utils.fromUuid(damageButton.dataset.itemId);
+        const lethal = damageButton.dataset.action === "roll-lethality";
+        item.roll({ lethal });
+      });
+    });
+  }
+
   const foundryMetadata = foundryHeader?.querySelector(".message-metadata");
   if (metadataSlot && foundryMetadata) {
     metadataSlot.replaceWith(foundryMetadata);

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -12,12 +12,12 @@ export default class DeltaGreenItem extends Item {
    * @param {Event} event   The originating click event
    * @private
    */
-  async roll(isCrit = false) {
+  async roll({ critical = false, lethal = false }) {
     // Basic template rendering data
     const item = this;
     const { actor } = this;
     let roll;
-    if (item.system.isLethal) {
+    if (lethal) {
       roll = new DGLethalityRoll(
         "1D100",
         {},
@@ -36,7 +36,7 @@ export default class DeltaGreenItem extends Item {
         item.system.skill,
       );
 
-      if (isCrit) {
+      if (critical) {
         diceFormula = `2*(${diceFormula})`;
       }
 

--- a/module/macros/macro-functions.js
+++ b/module/macros/macro-functions.js
@@ -186,7 +186,7 @@ export async function rollSkillTestAndDamageForOwnedItem(
   roll.toChat();
 
   if (roll.isSuccess && rollDamageOnSuccess) {
-    item.roll(roll.isCritical);
+    item.roll({ critical: roll.isCritical });
   }
 
   return roll.isSuccess;

--- a/module/roll/classes/dg-percentile-roll.js
+++ b/module/roll/classes/dg-percentile-roll.js
@@ -179,6 +179,8 @@ export class DGPercentileRoll extends DGRoll {
         resultString,
         formula: this.formula,
         total: this.total,
+        item: this.item,
+        successfulAttack: this.isSuccess && this.type === "weapon",
         failureMark,
       },
     );

--- a/scss/deltagreen/_chat-cards.scss
+++ b/scss/deltagreen/_chat-cards.scss
@@ -140,6 +140,17 @@
   margin-top: 0.5em;
 }
 
+.dg-result-actions {
+  display: flex;
+  flex-direction: column;
+  order: 98;
+  margin: 0.5em 0;
+}
+
+.dg-result-actions button {
+  margin-top: 0.5em;
+}
+
 .rollback-section {
   order: 99;
   display: flex;

--- a/templates/actor/partials/weapons-section-partial.html
+++ b/templates/actor/partials/weapons-section-partial.html
@@ -40,7 +40,6 @@
                          width="24"
                          height="24" />
                     <span>
-                        <span style="display: inline;" class="item-name">{{item.name}}</span>
                         <button type="button"
                                 class="rollable inline-roll"
                                 data-action="roll"
@@ -48,55 +47,56 @@
                                 data-rolltype="weapon"
                                 data-key="{{item.system.skill}}"
                                 title="{{localize 'DG.Tooltip.SkillLabel'}} ({{localizeWeaponSkill item.system.skill}})">
+                            <span style="display: inline;" class="item-name">{{item.name}}</span>
                             <i class="fas fa-dice" aria-hidden="true"></i>
                         </button>
                     </span>
                 </div>
 
-                {{#if (hasWeaponDamageAndLethality item)}}
-                <span class="centered-item-property weapons-col-damage rollable"
-                      data-action="roll"
-                      data-rolltype="damage-or-lethality"
-                      data-iid="{{item._id}}"
-                      title="{{localize 'DG.Gear.DamageOrLethality'}}">
-                    {{toUpperCase item.system.damage}}
-                    {{#if_eq item.system.skill 'unarmed_combat' }}
-                        {{actor.system.statistics.str.meleeDamageBonusFormula}}
-                    {{/if_eq}}
-                    {{#if_eq item.system.skill 'melee_weapons' }}
-                        {{actor.system.statistics.str.meleeDamageBonusFormula}}
-                    {{/if_eq}}
-                    / {{item.system.lethality}}%
-                    <i class="fas fa-dice" aria-hidden="true"></i>
-                </span>
+                {{#if (hasWeaponDamageAndLethality item) }}
+                    <span class="centered-item-property weapons-col-damage rollable"
+                          data-action="roll"
+                          data-rolltype="damage-or-lethality"
+                          data-iid="{{item._id}}"
+                          title="{{localize 'DG.Gear.DamageOrLethality'}}">
+                        {{toUpperCase item.system.damage}}
+                        {{#if_eq item.system.skill 'unarmed_combat' }}
+                            {{actor.system.statistics.str.meleeDamageBonusFormula}}
+                        {{/if_eq}}
+                        {{#if_eq item.system.skill 'melee_weapons' }}
+                            {{actor.system.statistics.str.meleeDamageBonusFormula}}
+                        {{/if_eq}}
+                        / {{item.system.lethality}}%
+                        <i class="fas fa-dice" aria-hidden="true"></i>
+                    </span>
                 {{else}}
-                    {{#if (hasWeaponDamage item.system.damage)}}
-                <span class="centered-item-property weapons-col-damage rollable"
-                      data-action="roll"
-                      data-rolltype="damage"
-                      data-iid="{{item._id}}"
-                      title="{{localize 'DG.Gear.DamageOrLethality'}}">
-                    {{toUpperCase item.system.damage}}
-                    {{#if_eq item.system.skill 'unarmed_combat' }}
-                        {{actor.system.statistics.str.meleeDamageBonusFormula}}
-                    {{/if_eq}}
-                    {{#if_eq item.system.skill 'melee_weapons' }}
-                        {{actor.system.statistics.str.meleeDamageBonusFormula}}
-                    {{/if_eq}}
-                    <i class="fas fa-dice" aria-hidden="true"></i>
-                </span>
+                    {{#if (hasWeaponDamage item.system.damage) }}
+                        <span class="centered-item-property weapons-col-damage rollable"
+                              data-action="roll"
+                              data-rolltype="damage"
+                              data-iid="{{item._id}}"
+                              title="{{localize 'DG.Gear.DamageOrLethality'}}">
+                            {{toUpperCase item.system.damage}}
+                            {{#if_eq item.system.skill 'unarmed_combat' }}
+                                {{actor.system.statistics.str.meleeDamageBonusFormula}}
+                            {{/if_eq}}
+                            {{#if_eq item.system.skill 'melee_weapons' }}
+                                {{actor.system.statistics.str.meleeDamageBonusFormula}}
+                            {{/if_eq}}
+                            <i class="fas fa-dice" aria-hidden="true"></i>
+                        </span>
                     {{else}}
-                        {{#if (hasWeaponLethality item.system.lethality)}}
-                <span class="centered-item-property weapons-col-damage rollable"
-                      data-action="roll"
-                      data-rolltype="lethality"
-                      data-iid="{{item._id}}"
-                      title="{{localize 'DG.ItemWindow.Weapons.LethalityTooltip'}}">
-                    {{item.system.lethality}}%
-                    <i class="fas fa-dice" aria-hidden="true"></i>
-                </span>
+                        {{#if (hasWeaponLethality item.system.lethality) }}
+                            <span class="centered-item-property weapons-col-damage rollable"
+                                  data-action="roll"
+                                  data-rolltype="lethality"
+                                  data-iid="{{item._id}}"
+                                  title="{{localize 'DG.ItemWindow.Weapons.LethalityTooltip'}}">
+                                {{item.system.lethality}}%
+                                <i class="fas fa-dice" aria-hidden="true"></i>
+                            </span>
                         {{else}}
-                <span class="centered-item-property weapons-col-damage"></span>
+                            <span class="centered-item-property weapons-col-damage"></span>
                         {{/if}}
                     {{/if}}
                 {{/if}}

--- a/templates/roll/percentile-roll.hbs
+++ b/templates/roll/percentile-roll.hbs
@@ -1,32 +1,49 @@
 <div class="dice-roll" data-action="expandRoll">
-  <div class="dice-result">
-    <div style="{{styleOverride}}" class="dice-formula">{{resultString}}</div>
-    <div class="dice-tooltip">
-      <div class="wrapper">
-        <section class="tooltip-part">
-          <div class="dice">
-            <header class="part-header flexrow">
-              <span class="part-formula">{{formula}}</span>
-              <span class="part-total">{{total}}</span>
-            </header>
-            <ol class="dice-rolls">
-              <li class="roll die {{formula}}">{{total}}</li>
-            </ol>
-          </div>
-        </section>
-      </div>
+    <div class="dice-result">
+        <div style="{{styleOverride}}" class="dice-formula">{{resultString}}</div>
+        <div class="dice-tooltip">
+            <div class="wrapper">
+                <section class="tooltip-part">
+                    <div class="dice">
+                        <header class="part-header flexrow">
+                            <span class="part-formula">{{formula}}</span>
+                            <span class="part-total">{{total}}</span>
+                        </header>
+                        <ol class="dice-rolls">
+                            <li class="roll die {{formula}}">{{total}}</li>
+                        </ol>
+                    </div>
+                </section>
+            </div>
+        </div>
+        <h4 class="dice-total">{{total}}</h4>
     </div>
-    <h4 class="dice-total">{{total}}</h4>
-  </div>
 
-  {{#if failureMark}}
-    <div class="rollback-section">
-      <label>{{localize 'DG.Messages.Skillsmark.Marked'}}</label>
-      <i class="fa fa-book" aria-hidden="true" data-tooltip="<p>{{localize 'DG.Messages.Skillsmark.Tooltip'}}</p>"></i>
-      <button type="button" data-action="rollback-skill-failure-state">
-        <i class="fa fa-undo" aria-hidden="true"></i>
-      </button>
-    </div>
-  {{/if}}
+    {{#if failureMark }}
+        <div class="rollback-section">
+            <label>{{localize 'DG.Messages.Skillsmark.Marked'}}</label>
+            <i class="fa fa-book"
+               aria-hidden="true"
+               data-tooltip="<p>{{localize 'DG.Messages.Skillsmark.Tooltip'}}</p>"></i>
+            <button type="button" data-action="rollback-skill-failure-state">
+                <i class="fa fa-undo" aria-hidden="true"></i>
+            </button>
+        </div>
+    {{/if}}
+
+    {{#if successfulAttack }}
+        <div class="dg-result-actions">
+            {{#if (hasWeaponDamage item.system.damage) }}
+                <button data-item-id={{item.uuid}} data-action="roll-damage">
+                    {{localize 'DG.Messages.RollDamage'}} {{ item.system.damage }}
+                </button>
+            {{/if}}
+            {{#if (hasWeaponLethality item.system.lethality) }}
+                <button data-item-id={{item.uuid}} data-action="roll-lethality">
+                    {{localize 'DG.Messages.RollLethality'}} {{ item.system.lethality }}%
+                </button>
+            {{/if}}
+        </div>
+    {{/if}}
 
 </div>


### PR DESCRIPTION
## Checklist

<!-- Check one or more: -->

- [x] This is meant for the next release.
- [ ] This is meant for a hotfix.
- [ ] This is a Build System change.
- [ ] This needs more reviewers than normal
- [ ] This intentionally introduces regressions that will be addressed later.
- [ ] The change will require updates to the documentation.
- [ ] Please do not send commits here without coordinating closely with the owner.

## What does this PR do?

When a roll for a weapon is successful, include buttons to allow the player quickly roll for damage or lethality.

Other adjustments:
- Move weapon label within roll button to make functionality align with rolling for damage on Combat page
- Refactor DeltaGreenItem.roll to accept params dictionary to enable easily providing optional arguments
- Add lethality flag to DeltaGreenItem.roll

<img width="1331" height="729" alt="136-roll-attacks-from-chat" src="https://github.com/user-attachments/assets/0e1aae64-6c7a-4231-bfe7-ca42282e7a88" />

## How to Test

1. Set an agents combat statistics to 100 to ensure success
1. Navigate to the Combat section of the Agent sheet
2. Click on any attack
3. Click on the **Roll Damage <dice roll>**
4. Click on any attack that has Lethality
5. Click on **Roll Damage <dice roll>** (if applicable)
6. Click on **Roll Lethality <lethality>%**

## Related Issue(s)

<!-- Link to issues this PR closes/fixes. Use GitHub auto-closing keywords if appropriate. -->

Closes #136

## Future Work

This was only tested and developed for the agent sheet and using items.
